### PR TITLE
Handle form state saving and notifying parents about changes + tests

### DIFF
--- a/__mocks__/react-jsonschema-form.tsx
+++ b/__mocks__/react-jsonschema-form.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export default class Form extends React.Component<any, any> {
+  public triggerChange(newData: any) {
+    this.props.onChange({ formData: newData });
+  };
+
+  public render() {
+    return null;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     ],
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
-      "\\.(css|less|sass)$": "identity-obj-proxy"
+      "\\.(css|less|sass|scss)$": "identity-obj-proxy"
     },
     "moduleFileExtensions": [
       "ts",

--- a/src/shared/components/experiment.test.tsx
+++ b/src/shared/components/experiment.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { Experiment } from "./experiment";
+import { mount } from "enzyme";
+import Form from "react-jsonschema-form";
+import { IExperiment } from "../experiment-types";
+import { act } from "react-dom/test-utils";
+
+jest.mock("react-jsonschema-form");
+
+describe("Experiment component", () => {
+  const experiment = {
+    uuid: "123",
+    name: "test",
+    initials: "tt",
+    schema: {
+      sections: [{
+        title: "Foo section",
+        formFields: ["foo"]
+      }],
+      dataSchema: {
+        type: "object",
+        properties: {
+          foo: {
+            type: "string"
+          },
+          bar: {
+            type: "number"
+          }
+        }
+      }
+    }
+  } as IExperiment;
+
+  it("immediately notifies parent when form is updated by the user", () => {
+    // This is somehow redundant to similar Section component tests,
+    // but it won't hurt and quite important to ensure that data is not lost.
+    const onDataChange = jest.fn();
+    const wrapper = mount(<Experiment experiment={experiment} onDataChange={onDataChange} />);
+    const form = wrapper.find(Form).instance();
+    expect(form).toBeDefined();
+    const newData = { foo: "test" };
+    act(() => {
+      // Mocked form, see __mocks__ dir.
+      (form as any).triggerChange(newData);
+      expect(onDataChange).toHaveBeenCalledWith(newData);
+    });
+  });
+});

--- a/src/shared/components/experiment.tsx
+++ b/src/shared/components/experiment.tsx
@@ -9,6 +9,8 @@ const DEFAULT_BOOTSTRAP_CSS = "../shared/themes/bootstrap-flatly.css";
 
 interface IProps {
   experiment: IExperiment;
+  data?: IExperimentData;
+  onDataChange?: (newData: IExperimentData) => void;
 }
 
 const addCSS = (href: string, asFirst = false) => {
@@ -33,11 +35,11 @@ const removeCSS = (href: string) => {
   }
 };
 
-export const Experiment: React.FC<IProps> = ({ experiment }) => {
+export const Experiment: React.FC<IProps> = ({ experiment, data, onDataChange }) => {
   const { schema } = experiment;
   const { sections } = schema;
   const [section, setSection] = useState<ISection>(sections[0]);
-  const [experimentData, setExperimentData] = useState<IExperimentData>({});
+  const [currentData, setCurrentData] = useState<IExperimentData>(data || {});
 
   useEffect(() => {
     // Append bootstrap css before our custom styles.
@@ -48,6 +50,13 @@ export const Experiment: React.FC<IProps> = ({ experiment }) => {
       schema.theme?.themeCSS?.forEach(link => removeCSS(link));
     }
   }, []);
+
+  const onExperimentDataChange = (newData: IExperimentData) => {
+    setCurrentData(newData);
+    if (onDataChange) {
+      onDataChange(newData);
+    }
+  };
 
   return (
     <div className={css.experiment}>
@@ -63,8 +72,8 @@ export const Experiment: React.FC<IProps> = ({ experiment }) => {
           section={section}
           dataSchema={schema.dataSchema}
           formUiSchema={schema.formUiSchema}
-          formData={experimentData}
-          onDataChange={setExperimentData}
+          formData={currentData}
+          onDataChange={onExperimentDataChange}
         />
       </div>
     </div>

--- a/src/shared/components/section.test.tsx
+++ b/src/shared/components/section.test.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Section } from "./section";
+import { mount } from "enzyme";
+import Form from "react-jsonschema-form";
+import { IDataSchema } from "../experiment-types";
+
+jest.mock("react-jsonschema-form");
+
+describe("Section component", () => {
+  const dataSchema = {
+    type: "object",
+    properties: {
+      foo: {
+        type: "string"
+      },
+      bar: {
+        type: "number"
+      }
+    }
+  } as IDataSchema;
+  const section = {
+    title: "Foo section",
+    formFields: ["foo"]
+  };
+
+  it("immediately notifies parent when form is updated by the user", () => {
+    const onDataChange = jest.fn();
+    const wrapper = mount(<Section dataSchema={dataSchema} section={section} formData={{}} onDataChange={onDataChange} />);
+    const form = wrapper.find(Form).instance();
+    expect(form).toBeDefined();
+    const newData = { foo: "test" };
+    // Mocked form, see __mocks__ dir.
+    (form as any).triggerChange(newData);
+    expect(onDataChange).toHaveBeenCalledWith(newData);
+  });
+});

--- a/src/shared/components/section.tsx
+++ b/src/shared/components/section.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { IDataSchema, IExperimentData, IFormUiSchema, ISection } from "../experiment-types";
-import Form, { ISubmitEvent } from "react-jsonschema-form";
+import Form, { IChangeEvent } from "react-jsonschema-form";
 import css from "./section.module.scss";
 
 interface IProps {
@@ -23,7 +23,10 @@ export const Section: React.FC<IProps> = ({ section, dataSchema, formUiSchema, f
     }
   }
 
-  const onSubmit = (event: ISubmitEvent<IExperimentData>) => onDataChange && onDataChange(event.formData);
+  const onChange = (event: IChangeEvent<IExperimentData>) => {
+    // Immediately save the data.
+    onDataChange && onDataChange(event.formData);
+  };
 
   return (
     <div className={css.section}>
@@ -37,8 +40,12 @@ export const Section: React.FC<IProps> = ({ section, dataSchema, formUiSchema, f
           schema={formSchema}
           uiSchema={formUiSchema}
           formData={formData}
-          onSubmit={onSubmit}
-        />
+          onChange={onChange}
+        >
+          {/* Children are used to render custom action buttons. We don't want any, */}
+          {/* as form is saving and validating data live. */}
+          <span />
+        </Form>
       }
     </div>
   );


### PR DESCRIPTION
[#170896583]

`Experiment` component can be treated both as an uncontrolled or controlled "input", so it's up to the wrapping component how it's being used. Data is saved on every change, there's no submit button and no validation (as that's what Leslie wanted for now, as the workflow is not clear if we try to validate the data).