### PR TITLE
Added versioning to experiment data [#170908848]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,14 @@
         "browserslist": "^4.8.2",
         "invariant": "^2.2.4",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "@babel/core": {
@@ -78,6 +86,12 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
         "source-map": {
@@ -158,6 +172,15 @@
         "invariant": "^2.2.4",
         "levenary": "^1.1.0",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "@babel/helper-create-regexp-features-plugin": {
@@ -944,6 +967,15 @@
         "invariant": "^2.2.2",
         "levenary": "^1.1.0",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "@babel/runtime-corejs2": {
@@ -2248,6 +2280,12 @@
         "@types/json-schema": "*",
         "@types/react": "*"
       }
+    },
+    "@types/semver": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.0.tgz",
+      "integrity": "sha512-1OzrNb4RuAzIT7wHSsgZRlMBlNsJl+do6UblR7JMW4oB7bbR+uBEYtUh7gEc/jM84GGilh68lSOokyM/zNUlBA==",
+      "dev": true
     },
     "@types/sizzle": {
       "version": "2.3.2",
@@ -4873,6 +4911,14 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "crypto-browserify": {
@@ -6737,8 +6783,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6762,15 +6807,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6787,22 +6830,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6933,8 +6973,7 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6948,7 +6987,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6965,7 +7003,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6974,8 +7011,7 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
@@ -7097,8 +7133,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7112,7 +7147,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7250,7 +7284,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7272,7 +7305,6 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7321,8 +7353,7 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
@@ -12323,6 +12354,12 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -12536,6 +12573,14 @@
         "is-builtin-module": "^1.0.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "normalize-path": {
@@ -12593,6 +12638,14 @@
             "semver": "^5.5.0",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
+            }
           }
         },
         "load-json-file": {
@@ -15229,10 +15282,9 @@
       }
     },
     "semver": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
-      "dev": true
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.1.tgz",
+      "integrity": "sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A=="
     },
     "send": {
       "version": "0.17.1",
@@ -16793,6 +16845,12 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
         "yargs-parser": {
           "version": "10.1.0",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
@@ -16920,6 +16978,12 @@
         "tsutils": "^2.29.0"
       },
       "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
         "tslib": {
           "version": "1.10.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
@@ -16949,6 +17013,12 @@
           "requires": {
             "glob": "^7.1.3"
           }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "jest": {
     "testURL": "https://vortex.unexisting.url.com",
     "setupFilesAfterEnv": [
-      "<rootDir>src/setupTests.js"
+      "<rootDir>src/setupTests.ts"
     ],
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
@@ -70,6 +70,7 @@
     "@types/react": "^16.9.19",
     "@types/react-dom": "^16.9.5",
     "@types/react-jsonschema-form": "^1.6.8",
+    "@types/semver": "^6.2.0",
     "@types/uuid": "^3.4.6",
     "autoprefixer": "^9.7.4",
     "babel-core": "^6.26.3",
@@ -108,6 +109,7 @@
   "dependencies": {
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
-    "react-jsonschema-form": "^1.8.1"
+    "react-jsonschema-form": "^1.8.1",
+    "semver": "^7.1.1"
   }
 }

--- a/src/data/experiments.json
+++ b/src/data/experiments.json
@@ -1,8 +1,11 @@
 [
   {
-    "uuid": "e431af00-5ef9-44f8-a887-c76caa6ddde1",
-    "name": "Schoolyard Investigation",
-    "initials": "SI",
+    "version": "1.0.0",
+    "metadata": {
+      "uuid": "e431af00-5ef9-44f8-a887-c76caa6ddde1",
+      "name": "Schoolyard Investigation",
+      "initials": "SI"
+    },
     "schema": {
       "sections": [
         {
@@ -71,9 +74,12 @@
     }
   },
   {
-    "uuid": "d27df06a-0997-4c53-8afd-d5dcc627d44f",
-    "name": "Stream Study",
-    "initials": "SS",
+    "version": "1.0.1",
+    "metadata": {
+      "uuid": "d27df06a-0997-4c53-8afd-d5dcc627d44f",
+      "name": "Stream Study",
+      "initials": "SS"
+    },
     "schema": {
       "sections": [
         {

--- a/src/mobile-app/components/experiment-picker.tsx
+++ b/src/mobile-app/components/experiment-picker.tsx
@@ -7,20 +7,22 @@ interface IProps {
 }
 
 export const ExperimentPicker: React.FC<IProps> = ({setExperiment}) => {
-  const experiments = useExperiments();
+  const {experiments, upgradeApp} = useExperiments();
 
   return (
     <div>
       <h1>Experiments</h1>
       <ul>
         {experiments.map(experiment => {
+          const {uuid, name, initials} = experiment.metadata;
           return (
-            <li key={experiment.uuid} onClick={setExperiment.bind(null, experiment)}>
-              {experiment.name} ({experiment.initials})
+            <li key={uuid} onClick={setExperiment.bind(null, experiment)}>
+              {name} ({initials})
             </li>
           );
         })}
       </ul>
+      {upgradeApp ? <div>Please upgrade this app to the latest version</div> : undefined}
     </div>
   );
 };

--- a/src/mobile-app/hooks/use-experiments.test.ts
+++ b/src/mobile-app/hooks/use-experiments.test.ts
@@ -1,6 +1,7 @@
 import { Experiments, useExperiments, IExperimentStorage, defaultStorage } from "./use-experiments";
 import { testHook, testAsyncHook } from "../../shared/test/test-hook";
-import { IExperimentSchema } from "../../shared/experiment-types";
+import { IExperimentSchema, EXPERIMENT_VERSION_1 } from "../../shared/experiment-types";
+import semver from "semver";
 const builtInExperiments = require("../../data/experiments.json") as Experiments;
 
 describe("use-experiments hook", () => {
@@ -14,30 +15,21 @@ describe("use-experiments hook", () => {
   };
   const savedExperiments: Experiments = [
     {
-      uuid: "first",
-      name: "First Experiment",
-      initials: "FE",
+      version: EXPERIMENT_VERSION_1,
+      metadata: {
+        uuid: "first",
+        name: "First Experiment",
+        initials: "FE",
+      },
       schema: emptySchema
     },
     {
-      uuid: "second",
-      name: "Second Experiment",
-      initials: "SE",
-      schema: emptySchema
-    },
-  ];
-
-  const downloadedExperiments: Experiments = [
-    {
-      uuid: "third",
-      name: "Third Experiment",
-      initials: "TE",
-      schema: emptySchema
-    },
-    {
-      uuid: "fourth",
-      name: "Fourth Experiment",
-      initials: "FE",
+      version: EXPERIMENT_VERSION_1,
+      metadata: {
+        uuid: "second",
+        name: "Second Experiment",
+        initials: "SE",
+      },
       schema: emptySchema
     },
   ];
@@ -48,7 +40,7 @@ describe("use-experiments hook", () => {
 
     const result = testHook(() => useExperiments(defaultStorage));
     expect(fetchMock).toHaveBeenCalled();
-    expect(result).toEqual(builtInExperiments);
+    expect(result).toEqual({experiments: builtInExperiments, upgradeApp: false});
   });
 
   it("returns previously saved experiments when no experiments are downloaded", () => {
@@ -62,10 +54,31 @@ describe("use-experiments hook", () => {
 
     const result = testHook(() => useExperiments(mockedStorage));
     expect(fetchMock).toHaveBeenCalled();
-    expect(result).toEqual(savedExperiments);
+    expect(result).toEqual({experiments: savedExperiments, upgradeApp: false});
   });
 
   it("returns previously saved experiments and saves downloaded experiments", async () => {
+    const downloadedExperiments: Experiments = [
+      {
+        version: EXPERIMENT_VERSION_1,
+        metadata: {
+          uuid: "third",
+          name: "Third Experiment",
+          initials: "TE",
+        },
+        schema: emptySchema
+      },
+      {
+        version: EXPERIMENT_VERSION_1,
+        metadata: {
+          uuid: "fourth",
+          name: "Fourth Experiment",
+          initials: "FE",
+        },
+        schema: emptySchema
+      },
+    ];
+
     const fetchMock = jest.fn(() => Promise.resolve({
       json: () => Promise.resolve(downloadedExperiments)
     }));
@@ -83,9 +96,56 @@ describe("use-experiments hook", () => {
     expect(fetchMock).toHaveBeenCalled();
 
     // it will return the saved experiments immediately
-    expect(result).toEqual(savedExperiments);
+    expect(result).toEqual({experiments: savedExperiments, upgradeApp: false});
 
     // but will have saved the downloaded experiments in the fetch handler
     expect(mockedStorageSave).toHaveBeenCalledWith(downloadedExperiments);
+
+    // LATER: figure out how to test setUseExperimentsResult() inside useEffect
+  });
+
+  it("does not save downloaded data if the experiments have a higher version", async () => {
+    const nextVersion = semver.inc(EXPERIMENT_VERSION_1, "patch") as any;
+    const downloadedExperiments: Experiments = [
+      {
+        version: nextVersion,
+        metadata: {
+          uuid: "third",
+          name: "Third Experiment",
+          initials: "TE",
+        },
+        schema: emptySchema
+      },
+      {
+        version: nextVersion,
+        metadata: {
+          uuid: "fourth",
+          name: "Fourth Experiment",
+          initials: "FE",
+        },
+        schema: emptySchema
+      },
+    ];
+
+    const fetchMock = jest.fn(() => Promise.resolve({
+      json: () => Promise.resolve(downloadedExperiments)
+    }));
+    (window as any).fetch = fetchMock;
+
+    const mockedStorageSave = jest.fn();
+    const mockedStorage: IExperimentStorage = {
+      load: () => savedExperiments,
+      save: mockedStorageSave
+    };
+
+    // need to use async test here otherwise the setExperiments call won't be done within
+    // the act() call in the hook test and will show a warning
+    const result = await testAsyncHook(() => useExperiments(mockedStorage));
+    expect(fetchMock).toHaveBeenCalled();
+
+    // will have NOT saved the downloaded experiments in the fetch handler (all are > current version)
+    expect(mockedStorageSave).not.toHaveBeenCalled();
+
+    // LATER: figure out how to test setUseExperimentsResult() inside useEffect
   });
 });

--- a/src/mobile-app/hooks/use-experiments.ts
+++ b/src/mobile-app/hooks/use-experiments.ts
@@ -1,11 +1,17 @@
+import semver from "semver";
 import { useState, useEffect } from "react";
-import { runningTests } from "../../shared/test/running-tests";
-import { IExperiment } from "../../shared/experiment-types";
+import { IExperiment, MAX_SUPPORTED_EXPERIMENT_VERSION, EXPERIMENT_VERSION_1 } from "../../shared/experiment-types";
+import { logError } from "../../shared/utils/log";
 const builtInExperiments = require("../../data/experiments.json") as Experiments;
 const updateUrl = "https://models-resources.concord.org/vortex/data/experiments.json";
 const localStorageKey = "experiments";
 
 export type Experiments = IExperiment[];
+
+export interface IUseExperimentsResult {
+  experiments: Experiments;
+  upgradeApp: boolean;
+}
 
 export interface IExperimentStorage {
   load: () => Experiments | undefined;
@@ -33,30 +39,70 @@ export class ExperimentStorage implements IExperimentStorage {
 
 export const defaultStorage = new ExperimentStorage();
 
+export const migrateAndFilterRemoteExperiments = (remoteExperiments: Experiments) => {
+  let save = false;
+  let upgradeRequired = false;
+  const filteredExperiments: Experiments = [];
+
+  remoteExperiments.forEach(experiment => {
+    if (semver.lte(experiment.version, MAX_SUPPORTED_EXPERIMENT_VERSION)) {
+      /*
+      TODO: when/if the version number is ever increased use something like the following
+            to migrate the data to the latest version supported by the app.
+
+      while (semver.neq(experiment.version, MAX_SUPPORTED_EXPERIMENT_VERSION)) {
+        switch (experiment.version) {
+          case EXPERIMENT_VERSION_1:
+            // no-op for now, if new version is added a migration would be added here
+            // migrating to the next version.  The loop would continue until the migration
+            // reaches the max supported version of the app
+            break;
+        }
+      }
+      */
+
+      filteredExperiments.push(experiment);
+      save = true;
+    } else {
+      upgradeRequired = true;
+    }
+  });
+
+  return {
+    save,
+    upgradeRequired,
+    filteredExperiments
+  }
+}
+
 export const useExperiments = (optionalStorage?: IExperimentStorage) => {
 
   // get the previously downloaded experiments (if any)
   const storage = optionalStorage || defaultStorage;
   const savedExperiments = storage.load();
 
-  const [experiments, setExperiments] = useState<Experiments>(savedExperiments || builtInExperiments);
+  const [useExperimentsResult, setUseExperimentsResult] = useState<IUseExperimentsResult>({
+    experiments: savedExperiments || builtInExperiments,
+    upgradeApp: false
+  });
 
-  // load the external json file each time time the consumer renders
-  // (so the user does not have to quit and reload the app)
   useEffect(() => {
     fetch(updateUrl)
       .then(resp => resp.json())
       .then(remoteExperiments => {
-        storage.save(remoteExperiments);
-        setExperiments(remoteExperiments);
+        const {save, upgradeRequired, filteredExperiments} = migrateAndFilterRemoteExperiments(remoteExperiments);
+        if (save) {
+          storage.save(filteredExperiments);
+        }
+        setUseExperimentsResult({
+          experiments: save ? filteredExperiments : useExperimentsResult.experiments,
+          upgradeApp: upgradeRequired
+        })
       })
       .catch(err => {
-        if (!runningTests) {
-          // tslint:disable:no-console
-          console.error("Unable to load remote experiments:", err);
-        }
+        logError("Unable to load remote experiments:", err);
       });
-  }, /* no dependencies here so that is runs on each render of the consumer */);
+  }, [] /* load the external json file once */ );
 
-  return experiments;
+  return useExperimentsResult;
 };

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,4 +1,0 @@
-const enzyme = require("enzyme");
-const Adapter = require("enzyme-adapter-react-16");
-
-enzyme.configure({ adapter: new Adapter() });

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,9 @@
+import { setLogLevel, LogLevel } from "./shared/utils/log";
+
+const enzyme = require("enzyme");
+const Adapter = require("enzyme-adapter-react-16");
+
+enzyme.configure({ adapter: new Adapter() });
+
+// prevent tests from being cluttered with log messages
+setLogLevel(LogLevel.None);

--- a/src/shared/components/experiment.test.tsx
+++ b/src/shared/components/experiment.test.tsx
@@ -2,16 +2,19 @@ import React from "react";
 import { Experiment } from "./experiment";
 import { mount } from "enzyme";
 import Form from "react-jsonschema-form";
-import { IExperiment } from "../experiment-types";
+import { IExperiment, EXPERIMENT_VERSION_1 } from "../experiment-types";
 import { act } from "react-dom/test-utils";
 
 jest.mock("react-jsonschema-form");
 
 describe("Experiment component", () => {
   const experiment = {
-    uuid: "123",
-    name: "test",
-    initials: "tt",
+    version: EXPERIMENT_VERSION_1,
+    metadata: {
+      uuid: "123",
+      name: "test",
+      initials: "tt",
+    },
     schema: {
       sections: [{
         title: "Foo section",

--- a/src/shared/experiment-types.ts
+++ b/src/shared/experiment-types.ts
@@ -34,12 +34,20 @@ export interface IExperimentSchema {
   theme?: ITheme;
 }
 
-export interface IExperiment {
-  uuid: string;
-  name: string;
-  initials: string;
+export const EXPERIMENT_VERSION_1 = "1.0.0"
+export const MAX_SUPPORTED_EXPERIMENT_VERSION = EXPERIMENT_VERSION_1
+
+export interface IExperimentV1 {
+  version: "1.0.0";
+  metadata: {
+    uuid: string;
+    name: string;
+    initials: string;
+  };
   schema: IExperimentSchema;
 }
+
+export type IExperiment = IExperimentV1
 
 // The only assumptions that can be made about experiment data is that it's an object.
 export type IExperimentData = object;

--- a/src/shared/index.tsx
+++ b/src/shared/index.tsx
@@ -1,14 +1,17 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { Experiment } from "./components/experiment";
-import { IExperiment } from "./experiment-types";
+import { IExperiment, EXPERIMENT_VERSION_1 } from "./experiment-types";
 
 import "./index.sass";
 
 const experiment: IExperiment = {
-  uuid: "test",
-  name: "Experiment #1",
-  initials: "E1",
+  version: EXPERIMENT_VERSION_1,
+  metadata: {
+    uuid: "test",
+    name: "Experiment #1",
+    initials: "E1",
+  },
   schema: {
     sections: [
       {

--- a/src/shared/test/running-tests.ts
+++ b/src/shared/test/running-tests.ts
@@ -1,1 +1,0 @@
-export const runningTests = process?.env?.JEST_WORKER_ID !== undefined;

--- a/src/shared/utils/log.ts
+++ b/src/shared/utils/log.ts
@@ -1,0 +1,40 @@
+export enum LogLevel {
+  None = 0,
+  Error = 1,
+  Warn = 2,
+  Info = 3,
+  Verbose = 4,
+  Debug = 5
+};
+
+const loggers = {
+  [LogLevel.None]: null,
+  // tslint:disable-next-line:no-console
+  [LogLevel.Error]: console.error,
+  // tslint:disable-next-line:no-console
+  [LogLevel.Warn]: console.warn,
+  // tslint:disable-next-line:no-console
+  [LogLevel.Info]: console.info,
+  // tslint:disable-next-line:no-console
+  [LogLevel.Verbose]: console.log,
+  // tslint:disable-next-line:no-console
+  [LogLevel.Debug]: console.debug,
+}
+
+let _logLevel: LogLevel = LogLevel.Error;
+
+export const logLevel = () => _logLevel;
+export const setLogLevel = (newLogLevel: LogLevel) => _logLevel = newLogLevel;
+
+export const log = (level: LogLevel, ...args: any) => {
+  const logger = loggers[level];
+  if ((level <= _logLevel) && logger) {
+    logger.apply(null, args);
+  }
+}
+
+export const logError = (...args: any) => log(LogLevel.Error, args);
+export const logWarn = (...args: any) => log(LogLevel.Warn, args);
+export const logInfo = (...args: any) => log(LogLevel.Info, args);
+export const logVerbose = (...args: any) => log(LogLevel.Verbose, args);
+export const logDebug = (...args: any) =>  log(LogLevel.Debug, args);


### PR DESCRIPTION
- Adds version field to experiment data
- Adds check for version number and placeholder for migrations
- Adds boolean return value to note is an app upgrade is required
- Moves experiment metadata into its own subobject
- Adds a logging facility with log levels
- Changes test setup to use TypeScript to allow log level to be set in tests
- Removes runningTests test helper function