### PR TITLE
Save experiment data locally in mobile-app

### DIFF
--- a/src/mobile-app/components/app.tsx
+++ b/src/mobile-app/components/app.tsx
@@ -1,20 +1,86 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useState } from "react";
 import { ExperimentPicker } from "./experiment-picker";
 import { ExperimentWrapper } from "./experiment-wrapper";
-import { IExperiment } from "../../shared/experiment-types";
+import { IExperiment, IExperimentData } from "../../shared/experiment-types";
+import { LocalDataStorage } from "../../shared/utils/local-data-storage";
+import { RunPicker } from "./run-picker";
+import { IRun } from "./types";
 
 import css from "./app.module.scss";
 
-export const AppComponent: React.FC<{}> = () => {
+const runsStorage = new LocalDataStorage<IRun>("runs-");
+const availableRunKeysStorage = new LocalDataStorage<string[]>("available-runs");
 
-  const [experiment, setExperiment] = useState<IExperiment|undefined>();
+export const AppComponent: React.FC = () => {
+  const [runKey, setRunKey] = useState<string | undefined>();
+  const [availableRunKeys, setAvailableRuns] = useState<string[]>(availableRunKeysStorage.load() || []);
+
+  useEffect(() => {
+    availableRunKeysStorage.save(availableRunKeys);
+  }, [availableRunKeys]);
+
+  useEffect(() => {
+    availableRunKeysStorage.save(availableRunKeys);
+  }, [availableRunKeys]);
+
+  const setupNewExperiment = (newExperiment: IExperiment) => {
+    const newRunKey = Date.now().toString(); // easy version of UUID
+    setRunKey(newRunKey);
+    setAvailableRuns(availableRunKeys.concat(newRunKey));
+    runsStorage.save({
+      key: newRunKey,
+      experiment: newExperiment,
+      data: { timestamp: Date.now() }
+    }, newRunKey);
+  };
+
+  const onDataChange = (newData: IExperimentData) => {
+    if (runKey) {
+      const run = runsStorage.load(runKey);
+      if (run) {
+        run.data = newData;
+        runsStorage.save(run, runKey);
+      }
+    }
+  };
+
+  const onBackBtnClick = () => {
+    setRunKey(undefined);
+  };
+
+  const resetLocalData = () => {
+    setAvailableRuns([]);
+  };
+
+  let runData = null;
+  let availableRuns: IRun[] = [];
+  if (runKey) {
+    runData = runsStorage.load(runKey);
+  } else {
+    availableRuns = availableRunKeys.map(key => runsStorage.load(key) as IRun).filter(run => run !== undefined);
+  }
 
   return (
     <div className={css.app}>
-      {experiment
-        ? <ExperimentWrapper experiment={experiment} setExperiment={setExperiment} />
-        : <ExperimentPicker setExperiment={setExperiment} />
+      {runData ?
+        <ExperimentWrapper
+          experiment={runData.experiment}
+          data={runData.data}
+          onDataChange={onDataChange}
+          onBackBtnClick={onBackBtnClick}
+        />
+        :
+        <>
+          <ExperimentPicker setExperiment={setupNewExperiment}/>
+          {
+            availableRuns.length > 0 &&
+            <>
+              <RunPicker runs={availableRuns} setRunKey={setRunKey}/>
+              <button onClick={resetLocalData} style={{ margin: 20 }}>Reset Local Data</button>
+            </>
+          }
+        </>
       }
     </div>
   );

--- a/src/mobile-app/components/app.tsx
+++ b/src/mobile-app/components/app.tsx
@@ -6,6 +6,7 @@ import { IExperiment, IExperimentData } from "../../shared/experiment-types";
 import { LocalDataStorage } from "../../shared/utils/local-data-storage";
 import { RunPicker } from "./run-picker";
 import { IRun } from "./types";
+import { useExperiments } from "../hooks/use-experiments";
 
 import css from "./app.module.scss";
 
@@ -13,6 +14,7 @@ const runsStorage = new LocalDataStorage<IRun>("runs-");
 const availableRunKeysStorage = new LocalDataStorage<string[]>("available-runs");
 
 export const AppComponent: React.FC = () => {
+  const { experiments, upgradeApp } = useExperiments();
   const [runKey, setRunKey] = useState<string | undefined>();
   const [availableRunKeys, setAvailableRuns] = useState<string[]>(availableRunKeysStorage.load() || []);
 
@@ -72,7 +74,7 @@ export const AppComponent: React.FC = () => {
         />
         :
         <>
-          <ExperimentPicker setExperiment={setupNewExperiment}/>
+          <ExperimentPicker experiments={experiments} setExperiment={setupNewExperiment}/>
           {
             availableRuns.length > 0 &&
             <>
@@ -82,6 +84,7 @@ export const AppComponent: React.FC = () => {
           }
         </>
       }
+      {upgradeApp ? <div>Please upgrade this app to the latest version</div> : undefined}
     </div>
   );
 };

--- a/src/mobile-app/components/experiment-picker.module.scss
+++ b/src/mobile-app/components/experiment-picker.module.scss
@@ -1,10 +1,6 @@
 @import "../../shared/components/variables.scss";
 
 .header {
-  position: absolute;
-  top: 0;
-  right: 0;
-  left: 0;
   height: $headerHeight;
   display: flex;
   flex-direction: row;
@@ -33,10 +29,7 @@
 }
 
 .workspace {
-  position: absolute;
   top: $headerHeight;
-  right: 0;
-  left: 0;
   overflow: auto;
   padding: 20px;
 }

--- a/src/mobile-app/components/experiment-picker.tsx
+++ b/src/mobile-app/components/experiment-picker.tsx
@@ -1,17 +1,15 @@
 import React from "react";
 import { ExperimentPickerItem } from "./experiment-picker-item";
-import { useExperiments } from "../hooks/use-experiments";
 import { IExperiment } from "../../shared/experiment-types";
 
 import css from "./experiment-picker.module.scss";
 
 interface IProps {
+  experiments: IExperiment[];
   setExperiment: (experiment: IExperiment) => void;
 }
 
-export const ExperimentPicker: React.FC<IProps> = ({setExperiment}) => {
-  const {experiments, upgradeApp} = useExperiments();
-
+export const ExperimentPicker: React.FC<IProps> = ({experiments, setExperiment}) => {
   return (
     <div>
       <div className={css.header}>
@@ -33,7 +31,6 @@ export const ExperimentPicker: React.FC<IProps> = ({setExperiment}) => {
             />
           ))}
         </div>
-        {upgradeApp ? <div>Please upgrade this app to the latest version</div> : undefined}
       </div>
     </div>
   );

--- a/src/mobile-app/components/experiment-wrapper.tsx
+++ b/src/mobile-app/components/experiment-wrapper.tsx
@@ -1,26 +1,29 @@
 import React from "react";
-import { IExperiment } from "../../shared/experiment-types";
+import { IExperiment, IExperimentData } from "../../shared/experiment-types";
 import { Experiment } from "../../shared/components/experiment";
 
 import css from "./experiment-wrapper.module.scss";
 
 interface IProps {
   experiment: IExperiment;
-  setExperiment: (experiment: IExperiment) => void;
+  data: IExperimentData;
+  onDataChange: (data: IExperimentData) => void;
+  onBackBtnClick: () => void;
 }
 
-export const ExperimentWrapper: React.FC<IProps> = ({ experiment, setExperiment }) => {
-  const { metadata: {initials} } = experiment;
+export const ExperimentWrapper: React.FC<IProps> = ({ experiment, data, onDataChange, onBackBtnClick }) => {
+  const { metadata } = experiment;
+  const { initials } = metadata;
 
   return (
     <div>
       <div className={css.header}>
-        <div className={css.headerBackIcon} onClick={setExperiment?.bind(null, undefined)}>⇦</div>
+        <div className={css.headerBackIcon} onClick={onBackBtnClick}>⇦</div>
         <div className={css.headerInitialsIcon}>{initials}</div>
         <div className={css.headerTitle}>TBD</div>
       </div>
       <div className={css.workspace}>
-        <Experiment experiment={experiment} />
+        <Experiment experiment={experiment} data={data} onDataChange={onDataChange}/>
       </div>
     </div>
   );

--- a/src/mobile-app/components/run-picker.module.scss
+++ b/src/mobile-app/components/run-picker.module.scss
@@ -1,0 +1,30 @@
+@import "../../shared/components/variables.scss";
+
+.runPicker {
+  padding: 20px;
+
+  .header {
+    font-size: 18px;
+    font-weight: bold;
+    font-stretch: normal;
+    font-style: normal;
+    line-height: normal;
+    letter-spacing: normal;
+    color: $fontColor;
+    margin-top: 10px;
+    margin-bottom: 10px;
+  }
+}
+
+.run {
+  padding: 10px;
+  margin-bottom: 10px;
+  background-color: $fontColor;
+  color: #fff;
+  border-radius: 5px;
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.3);
+
+  &:hover {
+    cursor: pointer;
+  }
+}

--- a/src/mobile-app/components/run-picker.tsx
+++ b/src/mobile-app/components/run-picker.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { IRun } from "./types";
+
+import css from "./run-picker.module.scss";
+
+interface IProps {
+  runs: IRun[];
+  setRunKey: (key: string) => void;
+}
+
+export const RunPicker: React.FC<IProps> = ({ runs, setRunKey }) => {
+  const count: {[name: string]: number} = {};
+
+  return (
+    <div className={css.runPicker}>
+      <hr />
+      <div className={css.header}>My Saved Experiments</div>
+      {
+        runs.map(run => {
+          const name = run.experiment.metadata.name;
+          if (!count[name]) {
+            count[name] = 1;
+          } else {
+            count[name] += 1;
+          }
+          return (
+            <div key={run.key} className={css.run} onClick={setRunKey.bind(null, run.key)}>
+              <div>{ name + ` #${count[name]}` }</div>
+              <div>{ new Date(run.data.timestamp).toString() }</div>
+            </div>
+          );
+        })
+      }
+    </div>
+  );
+};

--- a/src/mobile-app/components/types.ts
+++ b/src/mobile-app/components/types.ts
@@ -1,0 +1,7 @@
+import { IExperiment, IExperimentData } from "../../shared/experiment-types";
+
+export interface IRun {
+  key: string;
+  experiment: IExperiment;
+  data: IExperimentData;
+}

--- a/src/mobile-app/hooks/use-experiments.test.ts
+++ b/src/mobile-app/hooks/use-experiments.test.ts
@@ -1,4 +1,4 @@
-import { Experiments, useExperiments, IExperimentStorage, defaultStorage } from "./use-experiments";
+import { Experiments, useExperiments, defaultStorage } from "./use-experiments";
 import { testHook, testAsyncHook } from "../../shared/test/test-hook";
 import { IExperimentSchema, EXPERIMENT_VERSION_1 } from "../../shared/experiment-types";
 import semver from "semver";
@@ -47,7 +47,8 @@ describe("use-experiments hook", () => {
     const fetchMock = jest.fn().mockRejectedValue(new Error("test fetch failure"));
     (window as any).fetch = fetchMock;
 
-    const mockedStorage: IExperimentStorage = {
+    const mockedStorage = {
+      localStorageKeyPrefix: "",
       load: () => savedExperiments,
       save: () => undefined,
     };
@@ -85,7 +86,8 @@ describe("use-experiments hook", () => {
     (window as any).fetch = fetchMock;
 
     const mockedStorageSave = jest.fn();
-    const mockedStorage: IExperimentStorage = {
+    const mockedStorage = {
+      localStorageKeyPrefix: "",
       load: () => savedExperiments,
       save: mockedStorageSave
     };
@@ -133,7 +135,8 @@ describe("use-experiments hook", () => {
     (window as any).fetch = fetchMock;
 
     const mockedStorageSave = jest.fn();
-    const mockedStorage: IExperimentStorage = {
+    const mockedStorage = {
+      localStorageKeyPrefix: "",
       load: () => savedExperiments,
       save: mockedStorageSave
     };

--- a/src/mobile-app/hooks/use-experiments.ts
+++ b/src/mobile-app/hooks/use-experiments.ts
@@ -1,10 +1,10 @@
 import semver from "semver";
 import { useState, useEffect } from "react";
-import { IExperiment, MAX_SUPPORTED_EXPERIMENT_VERSION, EXPERIMENT_VERSION_1 } from "../../shared/experiment-types";
+import { IExperiment, MAX_SUPPORTED_EXPERIMENT_VERSION } from "../../shared/experiment-types";
 import { logError } from "../../shared/utils/log";
+import { LocalDataStorage } from "../../shared/utils/local-data-storage";
 const builtInExperiments = require("../../data/experiments.json") as Experiments;
 const updateUrl = "https://models-resources.concord.org/vortex/data/experiments.json";
-const localStorageKey = "experiments";
 
 export type Experiments = IExperiment[];
 
@@ -13,31 +13,7 @@ export interface IUseExperimentsResult {
   upgradeApp: boolean;
 }
 
-export interface IExperimentStorage {
-  load: () => Experiments | undefined;
-  save: (experiments: Experiments) => void;
-}
-
-export class ExperimentStorage implements IExperimentStorage {
-
-  public load() {
-    let savedExperiments: Experiments | undefined;
-    const stringifiedExperiments = window.localStorage.getItem(localStorageKey);
-    if (stringifiedExperiments) {
-      try {
-        savedExperiments = JSON.parse(stringifiedExperiments);
-      // tslint:disable-next-line:no-empty
-      } catch (e) {}
-    }
-    return savedExperiments;
-  }
-
-  public save(experiments: Experiments) {
-    window.localStorage.setItem(localStorageKey, JSON.stringify(experiments));
-  }
-}
-
-export const defaultStorage = new ExperimentStorage();
+export const defaultStorage = new LocalDataStorage<Experiments>("experiments");
 
 export const migrateAndFilterRemoteExperiments = (remoteExperiments: Experiments) => {
   let save = false;
@@ -75,7 +51,7 @@ export const migrateAndFilterRemoteExperiments = (remoteExperiments: Experiments
   }
 }
 
-export const useExperiments = (optionalStorage?: IExperimentStorage) => {
+export const useExperiments = (optionalStorage?: LocalDataStorage<Experiments>) => {
 
   // get the previously downloaded experiments (if any)
   const storage = optionalStorage || defaultStorage;

--- a/src/shared/components/experiment.tsx
+++ b/src/shared/components/experiment.tsx
@@ -12,10 +12,10 @@ interface IProps {
 }
 
 export const Experiment: React.FC<IProps> = ({ experiment, data, onDataChange }) => {
-  const { metadata: {initials}, schema } = experiment;
+  const { schema } = experiment;
   const { sections } = schema;
   const [section, setSection] = useState<ISection>(sections[0]);
-  const [currentData, setCurrentData] = useState<IExperimentData>(data || {});
+  const [currentData, setCurrentData] = useState<IExperimentData>(data || { timestamp: Date.now() });
 
   const onExperimentDataChange = (newData: IExperimentData) => {
     setCurrentData(newData);

--- a/src/shared/components/section.test.tsx
+++ b/src/shared/components/section.test.tsx
@@ -26,7 +26,7 @@ describe("Section component", () => {
 
   it("immediately notifies parent when form is updated by the user", () => {
     const onDataChange = jest.fn();
-    const wrapper = mount(<Section dataSchema={dataSchema} section={section} formData={{}} onDataChange={onDataChange} />);
+    const wrapper = mount(<Section dataSchema={dataSchema} section={section} formData={{timestamp: Date.now()}} onDataChange={onDataChange} />);
     const form = wrapper.find(Form).instance();
     expect(form).toBeDefined();
     const newData = { foo: "test" };

--- a/src/shared/experiment-types.ts
+++ b/src/shared/experiment-types.ts
@@ -46,5 +46,8 @@ export interface IExperimentV1 {
 
 export type IExperiment = IExperimentV1
 
-// The only assumptions that can be made about experiment data is that it's an object.
-export type IExperimentData = object;
+export interface IExperimentData {
+  // This will be injected by ExperimentWrapper automatically on initial load.
+  timestamp: number;
+  // Other properties are unknown, they're specified by Experiment dataSchema.
+}

--- a/src/shared/utils/local-data-storage.ts
+++ b/src/shared/utils/local-data-storage.ts
@@ -1,0 +1,24 @@
+export class LocalDataStorage<DataType> {
+  private localStorageKeyPrefix: string;
+
+  constructor(localStorageKeyPrefix: string) {
+    this.localStorageKeyPrefix = localStorageKeyPrefix;
+  }
+
+  public load(uuid = ""): DataType | undefined {
+    let data: DataType | undefined;
+    const stringifiedData = window.localStorage.getItem(this.localStorageKeyPrefix + uuid);
+    if (stringifiedData) {
+      try {
+        data = JSON.parse(stringifiedData);
+        // tslint:disable-next-line:no-empty
+      } catch (e) {
+      }
+    }
+    return data;
+  }
+
+  public save(data: DataType, uuid = "") {
+    window.localStorage.setItem(this.localStorageKeyPrefix + uuid, JSON.stringify(data));
+  }
+}

--- a/src/shared/utils/local-data-storage.ts
+++ b/src/shared/utils/local-data-storage.ts
@@ -1,5 +1,5 @@
 export class LocalDataStorage<DataType> {
-  private localStorageKeyPrefix: string;
+  public localStorageKeyPrefix: string = "";
 
   constructor(localStorageKeyPrefix: string) {
     this.localStorageKeyPrefix = localStorageKeyPrefix;


### PR DESCRIPTION
1. Users can start a new experiment, provide some data, use "back" button and see their saved experiment runs.
2. The app can be reloaded multiple times and the user can load his previously saved experiment run.
3. The second commit moves `useExperiments` to the main app component. It's a bit opinionated, so you can treat it like a proposal. Personally, I like to keep logic and data together in one, top-level component as long as possible. The app component can be treated as a poor replacement for MobX (but for now it's perfectly enough) and other components can have less state and logic. If we ever decide to use some state library, it should be easier to do it as the state won't be spread out in multiple components. Ofc there are some limits. Hooks are useful and sometimes it makes sense to add local state and hooks lower down in the component hierarchy.