### PR TITLE
Add section components (e.g. metadata), display selected form field as experiment title + misc changes

### DIFF
--- a/src/data/experiments.json
+++ b/src/data/experiments.json
@@ -7,6 +7,7 @@
       "initials": "SI"
     },
     "schema": {
+      "titleField": "label",
       "sections": [
         {
           "title": "Label",

--- a/src/data/experiments.json
+++ b/src/data/experiments.json
@@ -11,7 +11,8 @@
         {
           "title": "Label",
           "icon": "assignment",
-          "formFields": ["studySite", "label", "groupMembers"]
+          "formFields": ["studySite", "label", "groupMembers"],
+          "components": ["metadata"]
         },
         {
           "title": "Measure",

--- a/src/mobile-app/components/app.tsx
+++ b/src/mobile-app/components/app.tsx
@@ -1,48 +1,35 @@
 import React from "react";
-import { useState } from "react";
 import { ExperimentPicker } from "./experiment-picker";
 import { ExperimentWrapper } from "./experiment-wrapper";
-import { IExperiment, IExperimentData } from "../../shared/experiment-types";
 import { RunPicker } from "./run-picker";
-import { useRuns, IRun } from "../hooks/use-runs";
+import { useRuns } from "../hooks/use-runs";
 
 import css from "./app.module.scss";
 
 export const AppComponent: React.FC = () => {
-  const { runs, addNewRun, saveRunData, resetRuns } = useRuns();
-  const [ run, setRun ] = useState<IRun | null>(null);
-
-  const startExperiment = (experiment: IExperiment) => {
-    const newRun = addNewRun(experiment);
-    setRun(newRun);
-  };
+  const { runs, startNewRun, saveActiveRunData, resetRuns, activeRun, setActiveRun } = useRuns();
 
   const exitExperiment = () => {
-    setRun(null);
-  };
-
-  const handleDataChange = (data: IExperimentData) => {
-    if (run) {
-      saveRunData(run.key, data);
-    }
+    setActiveRun(null);
   };
 
   return (
     <div className={css.app}>
-      {run ?
+      {activeRun ?
         <ExperimentWrapper
-          experiment={run.experiment}
-          data={run.data}
-          onDataChange={handleDataChange}
+          experiment={activeRun.experiment}
+          experimentIdx={activeRun.experimentIdx}
+          data={activeRun.data}
+          onDataChange={saveActiveRunData}
           onBackBtnClick={exitExperiment}
         />
         :
         <>
-          <ExperimentPicker setExperiment={startExperiment}/>
+          <ExperimentPicker setExperiment={startNewRun}/>
           {
             runs.length > 0 &&
             <>
-              <RunPicker runs={runs} onRunSelect={setRun}/>
+              <RunPicker runs={runs} onRunSelect={setActiveRun}/>
               <button onClick={resetRuns} style={{ margin: 20 }}>Reset Local Data</button>
             </>
           }

--- a/src/mobile-app/components/experiment-wrapper.module.scss
+++ b/src/mobile-app/components/experiment-wrapper.module.scss
@@ -1,21 +1,18 @@
 @import "../../shared/components/variables.scss";
 
 .header {
-  position: absolute;
-  top: 0;
-  right: 0;
-  left: 0;
   height: $headerHeight;
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
   border-bottom: 2px solid #000;
+  align-items: center;
 }
 
 .headerBackIcon {
   width: $headerIconSize;
   height: $headerIconSize;
-  margin: $headerIconMargin 0 0 $headerIconMargin;
+  margin: 0 $headerIconMargin 0 $headerIconMargin;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -31,21 +28,9 @@
   }
 }
 
-.headerInitialsIcon {
-  width: $headerIconSize;
-  height: $headerIconSize;
-  margin: $headerIconMargin 0 0 $headerIconMargin;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: #dddddd;
-  color: #646464;
-  font-size: 26px;
-  border-radius: 5px;
-}
 
 .headerTitle {
-  margin: $headerIconMargin $headerIconMargin 0 $headerIconMargin;
+  margin: 0 $headerIconMargin 0 $headerIconMargin;
   font-size: 18px;
   font-weight: bold;
   color: #afafaf;

--- a/src/mobile-app/components/experiment-wrapper.tsx
+++ b/src/mobile-app/components/experiment-wrapper.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { IExperiment, IExperimentData } from "../../shared/experiment-types";
 import { Experiment } from "../../shared/components/experiment";
+import { Initials } from "../../shared/components/initials";
 
 import css from "./experiment-wrapper.module.scss";
 
@@ -19,7 +20,7 @@ export const ExperimentWrapper: React.FC<IProps> = ({ experiment, data, onDataCh
     <div>
       <div className={css.header}>
         <div className={css.headerBackIcon} onClick={onBackBtnClick}>⇦</div>
-        <div className={css.headerInitialsIcon}>{initials}</div>
+        <Initials text={initials}/>
         <div className={css.headerTitle}>TBD</div>
       </div>
       <div className={css.workspace}>

--- a/src/mobile-app/components/experiment-wrapper.tsx
+++ b/src/mobile-app/components/experiment-wrapper.tsx
@@ -7,21 +7,28 @@ import css from "./experiment-wrapper.module.scss";
 
 interface IProps {
   experiment: IExperiment;
+  experimentIdx: number;
   data: IExperimentData;
   onDataChange: (data: IExperimentData) => void;
   onBackBtnClick: () => void;
 }
 
-export const ExperimentWrapper: React.FC<IProps> = ({ experiment, data, onDataChange, onBackBtnClick }) => {
+export const ExperimentWrapper: React.FC<IProps> = ({ experiment, experimentIdx, data, onDataChange, onBackBtnClick }) => {
   const { metadata } = experiment;
   const { initials } = metadata;
-
+  let title = null;
+  if (experiment.schema.titleField) {
+    title = data[experiment.schema.titleField];
+  }
   return (
     <div>
       <div className={css.header}>
         <div className={css.headerBackIcon} onClick={onBackBtnClick}>⇦</div>
         <Initials text={initials}/>
-        <div className={css.headerTitle}>TBD</div>
+        <div className={css.headerTitle}>
+          <div>{`${experiment.metadata.name} #${experimentIdx}`}</div>
+          <div>{title}</div>
+        </div>
       </div>
       <div className={css.workspace}>
         <Experiment experiment={experiment} data={data} onDataChange={onDataChange}/>

--- a/src/mobile-app/components/run-picker.module.scss
+++ b/src/mobile-app/components/run-picker.module.scss
@@ -1,7 +1,7 @@
 @import "../../shared/components/variables.scss";
 
 .runPicker {
-  padding: 20px;
+  padding: 0 20px 20px 20px;
 
   .header {
     font-size: 18px;
@@ -11,20 +11,41 @@
     line-height: normal;
     letter-spacing: normal;
     color: $fontColor;
-    margin-top: 10px;
-    margin-bottom: 10px;
+    margin-top: 20px;
+    margin-bottom: 20px;
   }
-}
 
-.run {
-  padding: 10px;
-  margin-bottom: 10px;
-  background-color: $fontColor;
-  color: #fff;
-  border-radius: 5px;
-  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.3);
+  hr {
+    margin: 0;
+    border: solid 1px #afafaf;
+  }
 
-  &:hover {
-    cursor: pointer;
+  .run {
+    padding: 10px;
+    margin-bottom: 10px;
+    background-color: $fontColor;
+    font-size: 18px;
+    font-weight: 400;
+    font-stretch: normal;
+    font-style: normal;
+    line-height: normal;
+    letter-spacing: 0.45px;
+    color: #ffffff;
+    border-radius: 5px;
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.3);
+    display: flex;
+    flex-direction: row;
+
+    &:hover {
+      cursor: pointer;
+    }
+
+    .text {
+      margin-left: 10px;
+    }
+
+    .date {
+      font-weight: 300;
+    }
   }
 }

--- a/src/mobile-app/components/run-picker.tsx
+++ b/src/mobile-app/components/run-picker.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { IRun } from "../hooks/use-runs";
 
 import css from "./run-picker.module.scss";
+import { formatTime } from "../../shared/utils/format-time";
+import { Initials } from "../../shared/components/initials";
 
 interface IProps {
   runs: IRun[];
@@ -9,27 +11,24 @@ interface IProps {
 }
 
 export const RunPicker: React.FC<IProps> = ({ runs, onRunSelect }) => {
-  const count: {[name: string]: number} = {};
-
   return (
     <div className={css.runPicker}>
-      <hr />
+      <hr/>
       <div className={css.header}>My Saved Experiments</div>
       {
-        runs.map(run => {
-          const name = run.experiment.metadata.name;
-          if (!count[name]) {
-            count[name] = 1;
-          } else {
-            count[name] += 1;
-          }
-          return (
-            <div key={run.key} className={css.run} onClick={onRunSelect.bind(null, run)}>
-              <div>{ name + ` #${count[name]}` }</div>
-              <div>{ new Date(run.data.timestamp).toString() }</div>
+        runs.map(run =>
+          <div key={run.key} className={css.run} onClick={onRunSelect.bind(null, run)}>
+            <Initials text={run.experiment.metadata.initials}/>
+            <div className={css.text}>
+              <div>{run.experiment.metadata.name + ` #${run.experimentIdx}`}</div>
+              {
+                run.experiment.schema.titleField && run.data[run.experiment.schema.titleField] &&
+                <div>{run.data[run.experiment.schema.titleField]}</div>
+              }
+              <div className={css.date}>{formatTime(run.data.timestamp)}</div>
             </div>
-          );
-        })
+          </div>
+        )
       }
     </div>
   );

--- a/src/mobile-app/hooks/use-runs.test.tsx
+++ b/src/mobile-app/hooks/use-runs.test.tsx
@@ -8,25 +8,32 @@ describe("use-runs hook", () => {
   });
 
   // We don't care about experiment content in these tests.
-  const testExperiment = {} as any as IExperiment;
+  const testExperiment = {
+    metadata: {
+      name: "test"
+    }
+  } as any as IExperiment;
   const testData = { testData: 123 } as any as IExperimentData;
 
   it("returns empty list of runs if there's no saved data in local storage", () => {
     const { result } = renderHook(() => useRuns());
     expect(result.current.runs).toEqual([]);
+    expect(result.current.activeRun).toEqual(null);
   });
 
   it("returns previously added runs", () => {
     const { result } = renderHook(() => useRuns());
     let run1;
     act(() => {
-      run1 = result.current.addNewRun(testExperiment);
+      run1 = result.current.startNewRun(testExperiment);
     });
     expect(result.current.runs.length).toBe(1);
+    expect(result.current.activeRun).toBe(run1);
     let run2;
     act(() => {
-      run2 = result.current.addNewRun(testExperiment);
+      run2 = result.current.startNewRun(testExperiment);
     });
+    expect(result.current.activeRun).toBe(run2);
     expect(result.current.runs.length).toBe(2);
     expect(result.current.runs[0]).toEqual(run1);
     expect(result.current.runs[1]).toEqual(run2);
@@ -34,22 +41,46 @@ describe("use-runs hook", () => {
 
   it("saves experiment run data", () => {
     const { result } = renderHook(() => useRuns());
-    let run: IRun;
+    let run;
     act(() => {
-      run = result.current.addNewRun(testExperiment);
+      run = result.current.startNewRun(testExperiment);
     });
+    expect(result.current.activeRun).toEqual(run);
     act(() => {
-      result.current.saveRunData(run.key, testData);
+      result.current.saveActiveRunData(testData);
     });
     expect(result.current.runs.length).toEqual(1);
+    expect(result.current.activeRun!.data).toEqual(testData);
     expect(result.current.runs[0].data).toEqual(testData);
+  });
+
+  it("provides a way to change active run", () => {
+    const { result } = renderHook(() => useRuns());
+    let run1: IRun | null = null;
+    act(() => {
+      run1 = result.current.startNewRun(testExperiment);
+    });
+    expect(result.current.activeRun).toEqual(run1);
+    let run2;
+    act(() => {
+      run2 = result.current.startNewRun(testExperiment);
+    });
+    expect(result.current.activeRun).toEqual(run2);
+    act(() => {
+      result.current.setActiveRun(run1);
+    });
+    expect(result.current.activeRun).toEqual(run1);
+    act(() => {
+      result.current.setActiveRun(null);
+    });
+    expect(result.current.activeRun).toEqual(null);
   });
 
   it("resets runs", () => {
     const { result } = renderHook(() => useRuns());
     let run1;
     act(() => {
-      run1 = result.current.addNewRun(testExperiment);
+      run1 = result.current.startNewRun(testExperiment);
     });
     expect(result.current.runs.length).toEqual(1);
     act(() => {

--- a/src/shared/components/experiment.module.scss
+++ b/src/shared/components/experiment.module.scss
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css?family=Londrina+Solid&display=swap");
+@import url("https://fonts.googleapis.com/css?family=Londrina+Solid:300,400&display=swap");
 @import "variables";
 
 .experiment {

--- a/src/shared/components/experiment.tsx
+++ b/src/shared/components/experiment.tsx
@@ -42,8 +42,7 @@ export const Experiment: React.FC<IProps> = ({ experiment, data, onDataChange })
       <div className={css.sectionContainer}>
         <Section
           section={section}
-          dataSchema={schema.dataSchema}
-          formUiSchema={schema.formUiSchema}
+          experiment={experiment}
           formData={currentData}
           onDataChange={onExperimentDataChange}
         />

--- a/src/shared/components/initials.module.scss
+++ b/src/shared/components/initials.module.scss
@@ -1,0 +1,13 @@
+@import "../../shared/components/variables.scss";
+
+.initialsIcon {
+  width: $headerIconSize;
+  height: $headerIconSize;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #dddddd;
+  color: #646464;
+  font-size: 26px;
+  border-radius: 5px;
+}

--- a/src/shared/components/initials.tsx
+++ b/src/shared/components/initials.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import css from "./initials.module.scss";
+
+interface IProps {
+  text: string;
+}
+
+export const Initials: React.FC<IProps> = ({ text }) => {
+  return <div className={css.initialsIcon}>{text}</div>;
+};

--- a/src/shared/components/metadata.module.scss
+++ b/src/shared/components/metadata.module.scss
@@ -1,0 +1,25 @@
+@import "variables";
+
+.metadata {
+  .main {
+    display: flex;
+    align-items: center;
+  }
+
+  .text {
+    font-size: 20px;
+    font-weight: normal;
+    font-stretch: normal;
+    font-style: normal;
+    line-height: normal;
+    letter-spacing: 0.56px;
+    color: #00c30b;
+    margin-left: 10px;
+  }
+
+  hr {
+    margin-top: 25px;
+    margin-bottom: 20px;
+    border: solid 0.5px $fontColor;
+  }
+}

--- a/src/shared/components/metadata.tsx
+++ b/src/shared/components/metadata.tsx
@@ -2,20 +2,16 @@ import React from "react";
 import { Initials } from "./initials";
 import css from "./metadata.module.scss";
 import { SectionComponent } from "../experiment-types";
-
-const dateOptions: Intl.DateTimeFormatOptions = {
-  weekday: "short", year: "numeric", month: "long", day: "numeric", hour: "numeric", minute: "numeric", hour12: true
-};
+import { formatTime } from "../utils/format-time";
 
 export const Metadata: SectionComponent = ({ experiment, data }) => {
-  const date = new Date(data.timestamp);
   return (
     <div className={css.metadata}>
       <div className={css.main}>
         <Initials text={experiment.metadata.initials}/>
         <div className={css.text}>
           <div className={css.name}>{experiment.metadata.name}</div>
-          <div className={css.timestamp}>{date.toLocaleString("en-US", dateOptions)}</div>
+          <div className={css.timestamp}>{formatTime(data.timestamp)}</div>
         </div>
       </div>
       <hr/>

--- a/src/shared/components/metadata.tsx
+++ b/src/shared/components/metadata.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Initials } from "./initials";
+import css from "./metadata.module.scss";
+import { SectionComponent } from "../experiment-types";
+
+const dateOptions: Intl.DateTimeFormatOptions = {
+  weekday: "short", year: "numeric", month: "long", day: "numeric", hour: "numeric", minute: "numeric", hour12: true
+};
+
+export const Metadata: SectionComponent = ({ experiment, data }) => {
+  const date = new Date(data.timestamp);
+  return (
+    <div className={css.metadata}>
+      <div className={css.main}>
+        <Initials text={experiment.metadata.initials}/>
+        <div className={css.text}>
+          <div className={css.name}>{experiment.metadata.name}</div>
+          <div className={css.timestamp}>{date.toLocaleString("en-US", dateOptions)}</div>
+        </div>
+      </div>
+      <hr/>
+    </div>
+  );
+};

--- a/src/shared/components/section.test.tsx
+++ b/src/shared/components/section.test.tsx
@@ -2,22 +2,26 @@ import React from "react";
 import { Section } from "./section";
 import { mount } from "enzyme";
 import Form from "react-jsonschema-form";
-import { IDataSchema } from "../experiment-types";
+import { IDataSchema, IExperiment } from "../experiment-types";
 
 jest.mock("react-jsonschema-form");
 
 describe("Section component", () => {
-  const dataSchema = {
-    type: "object",
-    properties: {
-      foo: {
-        type: "string"
-      },
-      bar: {
-        type: "number"
-      }
+  const experiment = {
+    schema: {
+      dataSchema: {
+        type: "object",
+        properties: {
+          foo: {
+            type: "string"
+          },
+          bar: {
+            type: "number"
+          }
+        }
+      } as IDataSchema
     }
-  } as IDataSchema;
+  } as IExperiment;
   const section = {
     title: "Foo section",
     icon: "test",
@@ -26,7 +30,7 @@ describe("Section component", () => {
 
   it("immediately notifies parent when form is updated by the user", () => {
     const onDataChange = jest.fn();
-    const wrapper = mount(<Section dataSchema={dataSchema} section={section} formData={{timestamp: Date.now()}} onDataChange={onDataChange} />);
+    const wrapper = mount(<Section experiment={experiment} section={section} formData={{timestamp: Date.now()}} onDataChange={onDataChange} />);
     const form = wrapper.find(Form).instance();
     expect(form).toBeDefined();
     const newData = { foo: "test" };

--- a/src/shared/experiment-types.ts
+++ b/src/shared/experiment-types.ts
@@ -15,12 +15,16 @@ export interface IFormUiSchema extends UiSchema {
   "ui:icon"?: "string";
 }
 
+// For now there's only supported section component - "metadata". In the future, this list might grow.
+export type SectionComponentName = "metadata";
+
 export interface ISection {
   title: string;
   icon: string;
   // formFields array should be a subset of dataSchema.properties.
   // Section will render a form with these fields.
   formFields?: string[];
+  components?: SectionComponentName[];
 }
 
 export interface IExperimentSchema {
@@ -31,8 +35,8 @@ export interface IExperimentSchema {
   sections: ISection[];
 }
 
-export const EXPERIMENT_VERSION_1 = "1.0.0"
-export const MAX_SUPPORTED_EXPERIMENT_VERSION = EXPERIMENT_VERSION_1
+export const EXPERIMENT_VERSION_1 = "1.0.0";
+export const MAX_SUPPORTED_EXPERIMENT_VERSION = EXPERIMENT_VERSION_1;
 
 export interface IExperimentV1 {
   version: "1.0.0";
@@ -51,3 +55,11 @@ export interface IExperimentData {
   timestamp: number;
   // Other properties are unknown, they're specified by Experiment dataSchema.
 }
+
+// Custom components listed by sections should accept these properties.
+export interface ISectionComponentProps {
+  experiment: IExperiment;
+  data: IExperimentData;
+}
+
+export type SectionComponent = React.FC<ISectionComponentProps>;

--- a/src/shared/experiment-types.ts
+++ b/src/shared/experiment-types.ts
@@ -32,7 +32,10 @@ export interface IExperimentSchema {
   dataSchema: IDataSchema;
   // React JSONSchema Form uiSchema, see: https://react-jsonschema-form.readthedocs.io/en/latest/form-customization/#the-uischema-object
   formUiSchema?: IFormUiSchema;
+  // Sections list. Sections specify form fields to render and section components.
   sections: ISection[];
+  // Form data property name that will be echoed to the top of the app experiment screen as a title.
+  titleField?: string;
 }
 
 export const EXPERIMENT_VERSION_1 = "1.0.0";
@@ -54,6 +57,7 @@ export interface IExperimentData {
   // This will be injected by ExperimentWrapper automatically on initial load.
   timestamp: number;
   // Other properties are unknown, they're specified by Experiment dataSchema.
+  [name: string]: any;
 }
 
 // Custom components listed by sections should accept these properties.

--- a/src/shared/utils/format-time.ts
+++ b/src/shared/utils/format-time.ts
@@ -1,0 +1,11 @@
+const dateOptions: Intl.DateTimeFormatOptions = {
+  weekday: "short",
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+  hour12: true
+};
+
+export const formatTime = (timestamp: number) => new Date(timestamp).toLocaleString("en-US", dateOptions);


### PR DESCRIPTION
1. Add section components (`Metadata` component) + specify types for future section components.
2. Display selected form field as experiment title (`titleField` in experiment schema).
3. Refactor use-runs, move more functionality there + update specs.
4. Style experiment header.
5. Style runs picker.

BTW, I'm wondering if we need `experiment.schema` field? I guess we could move schema fields one level higher to have fewer nested objects and avoid decision making where to put a new field (top-level experiment or schema). :wink: