### PR TITLE
Add data table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.1.tgz",
       "integrity": "sha512-Z+6ZOXvyOWYxJ50BwxzdhRnRsGST8Y3jaZgxYig575lTjVSs3KtJnmESwZegg6e2Dn0td1eDhoWlp1wI4BTCPw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "browserslist": "^4.8.2",
         "invariant": "^2.2.4",
@@ -28,7 +29,8 @@
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -133,6 +135,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz",
       "integrity": "sha512-6o+mJrZBxOoEX77Ezv9zwW7WV8DdluouRKNY/IR5u/YTMuKHgugHOzYWlYvYLpLA9nPsQCAAASpCIbjI9Mv+Uw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/types": "^7.8.3"
       }
@@ -188,6 +191,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.3.tgz",
       "integrity": "sha512-Gcsm1OHCUr9o9TcJln57xhWHtdXbA2pgQ58S0Lxlks0WMGNXuki4+GLfX0p+L2ZkINUGZvfkz8rzoqJQSthI+Q==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-regex": "^7.8.3",
         "regexpu-core": "^4.6.0"
@@ -241,6 +245,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.8.3.tgz",
       "integrity": "sha512-ky1JLOjcDUtSc+xkt0xhYff7Z6ILTAHKmZLHPxAhOP0Nd77O+3nCsd6uSVYur6nJnCI029CrNbYlc0LoPfAPQg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/types": "^7.8.3"
       }
@@ -250,6 +255,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
       "integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/types": "^7.8.3"
       }
@@ -259,6 +265,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
       "integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/types": "^7.8.3"
       }
@@ -268,6 +275,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.8.3.tgz",
       "integrity": "sha512-C7NG6B7vfBa/pwCOshpMbOYUmrYQDfCpVL/JCRu0ek8B5p8kue1+BCXpg2vOYs7w5ACB9GTOBYQ5U6NwrMg+3Q==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/helper-simple-access": "^7.8.3",
@@ -282,6 +290,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
       "integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/types": "^7.8.3"
       }
@@ -297,6 +306,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.8.3.tgz",
       "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "lodash": "^4.17.13"
       }
@@ -306,6 +316,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.8.3.tgz",
       "integrity": "sha512-kgwDmw4fCg7AVgS4DukQR/roGp+jP+XluJE5hsRZwxCYGg+Rv9wSGErDWhlI90FODdYfd4xG4AQRiMDjjN0GzA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.8.3",
         "@babel/helper-wrap-function": "^7.8.3",
@@ -319,6 +330,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.3.tgz",
       "integrity": "sha512-xOUssL6ho41U81etpLoT2RTdvdus4VfHamCuAm4AHxGr+0it5fnwoVdwUJ7GFEqCsQYzJUhcbsN9wB9apcYKFA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.8.3",
         "@babel/helper-optimise-call-expression": "^7.8.3",
@@ -331,6 +343,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
       "integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/template": "^7.8.3",
         "@babel/types": "^7.8.3"
@@ -350,6 +363,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz",
       "integrity": "sha512-LACJrbUET9cQDzb6kG7EeD7+7doC3JNvUgTEQOx2qaO1fKlzE/Bf05qs9w1oXQMmXlPO65lC3Tq9S6gZpTErEQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-function-name": "^7.8.3",
         "@babel/template": "^7.8.3",
@@ -479,6 +493,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
       "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
       }
@@ -497,6 +512,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
       "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
       }
@@ -506,6 +522,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
       "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
       }
@@ -515,6 +532,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
       "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
       }
@@ -533,6 +551,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
       "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
       }
@@ -542,6 +561,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
       "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
       }
@@ -3754,6 +3774,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
       "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "object.assign": "^4.1.0"
       }
@@ -4213,6 +4234,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.5.tgz",
       "integrity": "sha512-4LMHuicxkabIB+n9874jZX/az1IaZ5a+EUuvD7KFOu9x/Bd5YHyO0DIz2ls/Kl8g0ItS4X/ilEgf4T1Br0lgSg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "caniuse-lite": "^1.0.30001022",
         "electron-to-chromium": "^1.3.338",
@@ -4435,7 +4457,8 @@
       "version": "1.0.30001022",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001022.tgz",
       "integrity": "sha512-FjwPPtt/I07KyLPkBQ0g7/XuZg6oUkYBVnPHNj3VHJbOjmmJ/GdSo/GUY6MwINEQvjhP6WZVbX8Tvms8xh0D5A==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -5881,7 +5904,8 @@
       "version": "1.3.340",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.340.tgz",
       "integrity": "sha512-hRFBAglhcj5iVYH+o8QU0+XId1WGoc0VGowJB1cuJAt3exHGrivZvWeAO5BRgBZqwZtwxjm8a5MQeGoT/Su3ww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -6987,7 +7011,8 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7011,13 +7036,15 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7034,19 +7061,22 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7177,7 +7207,8 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7191,6 +7222,7 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7207,6 +7239,7 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7215,13 +7248,15 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7242,6 +7277,7 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7337,7 +7373,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7351,6 +7388,7 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7446,7 +7484,8 @@
           "version": "5.1.2",
           "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7488,6 +7527,7 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7509,6 +7549,7 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7557,13 +7598,15 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -11740,6 +11783,7 @@
       "resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.0.tgz",
       "integrity": "sha512-VHcwhO0UTpUW7rLPN2/OiWJdgA1e9BqEDALhrgCe/F+uUJnep6CoUsTzMeP8Rh0NGr9uKquXxqe7lwLZo509nQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "leven": "^3.1.0"
       }
@@ -12777,6 +12821,7 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.47.tgz",
       "integrity": "sha512-k4xjVPx5FpwBUj0Gw7uvFOTF4Ep8Hok1I6qjwL3pLfwe7Y0REQSAqOwwv9TWBCUtMHxcXfY4PgRLRozcChvTcA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "semver": "^6.3.0"
       },
@@ -12785,7 +12830,8 @@
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -14811,13 +14857,15 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
       "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "regenerate-unicode-properties": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
       "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "regenerate": "^1.4.0"
       }
@@ -14925,6 +14973,7 @@
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
       "integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "regenerate": "^1.4.0",
         "regenerate-unicode-properties": "^8.1.0",
@@ -14938,13 +14987,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
       "integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "regjsparser": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.2.tgz",
       "integrity": "sha512-E9ghzUtoLwDekPT0DYCp+c4h+bvuUpe6rRHCTYn6eGoqj1LgKXxT6I0Il4WbjhQkOghzi/V+y03bPKvbllL93Q==",
       "dev": true,
+      "optional": true,
       "requires": {
         "jsesc": "~0.5.0"
       },
@@ -14953,7 +15004,8 @@
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -17248,13 +17300,15 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
       "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "unicode-match-property-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
       "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "unicode-canonical-property-names-ecmascript": "^1.0.4",
         "unicode-property-aliases-ecmascript": "^1.0.4"
@@ -17264,13 +17318,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
       "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "unicode-property-aliases-ecmascript": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
       "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "union-value": {
       "version": "1.0.1",

--- a/src/data/experiments.json
+++ b/src/data/experiments.json
@@ -56,28 +56,26 @@
             "type": "string"
           },
           "experimentData": {
-            "title": "Experiment Data",
-            "type": "object",
-            "properties": {
-              "temperature": {
-                "title": "Temperature",
-                "type": "array",
-                "items": {
-                  "type": ["null", "number"]
-                }
-              },
-              "light": {
-                "title": "Light",
-                "type": "array",
-                "items": {
-                  "type": ["null", "number"]
-                }
-              },
-              "humidity": {
-                "title": "Humidity",
-                "type": "array",
-                "items": {
-                  "type": ["null", "number"]
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["location"],
+              "properties": {
+                "location": {
+                  "title": "Location",
+                  "type": "string"
+                },
+                "temperature": {
+                  "title": "Temperature",
+                  "type": "number"
+                },
+                "light": {
+                  "title": "Light",
+                  "type": "number"
+                },
+                "humidity": {
+                  "title": "Humidity",
+                  "type": "number"
                 }
               }
             }
@@ -108,6 +106,9 @@
           "items": {
             "ui:widget": "textarea"
           }
+        },
+        "experimentData": {
+          "ui:field": "dataTable"
         }
       }
     }

--- a/src/data/experiments.json
+++ b/src/data/experiments.json
@@ -63,18 +63,19 @@
               "properties": {
                 "location": {
                   "title": "Location",
-                  "type": "string"
+                  "type": "string",
+                  "readOnly": true
                 },
                 "temperature": {
-                  "title": "Temperature",
+                  "title": "Temperature (°C)",
                   "type": "number"
                 },
-                "light": {
-                  "title": "Light",
+                "illuminance": {
+                  "title": "Illuminance (lux)",
                   "type": "number"
                 },
                 "humidity": {
-                  "title": "Humidity",
+                  "title": "Humidity (%)",
                   "type": "number"
                 }
               }
@@ -108,9 +109,21 @@
           }
         },
         "experimentData": {
-          "ui:field": "dataTable"
+          "ui:field": "dataTable",
+          "ui:dataTableOptions": {
+            "sensorFields": ["temperature", "humidity", "illuminance"]
+          }
         }
       }
+    },
+    "data": {
+      "experimentData": [
+        {"location": "Corner 1"},
+        {"location": "Corner 2"},
+        {"location": "Corner 3"},
+        {"location": "Corner 4"},
+        {"location": "Center"}
+      ]
     }
   },
   {

--- a/src/data/experiments.json
+++ b/src/data/experiments.json
@@ -39,8 +39,8 @@
             "title": "Study Site",
             "type": "string",
             "enum": [
-              "site1",
-              "site2"
+              "Site @1: Conservation Practice in Place",
+              "Site @2"
             ],
             "enumNames": [
               "Site @1: Conservation Practice in Place",
@@ -111,7 +111,8 @@
         "experimentData": {
           "ui:field": "dataTable",
           "ui:dataTableOptions": {
-            "sensorFields": ["temperature", "humidity", "illuminance"]
+            "sensorFields": ["temperature", "humidity", "illuminance"],
+            "titleField": "studySite"
           }
         }
       }

--- a/src/data/experiments.json
+++ b/src/data/experiments.json
@@ -122,7 +122,7 @@
         {"location": "Corner 2"},
         {"location": "Corner 3"},
         {"location": "Corner 4"},
-        {"location": "Center"}
+        {"location": "Average", "temperature":  "<AVG>", "humidity": "<AVG>", "illuminance": "<AVG>"}
       ]
     }
   },

--- a/src/mobile-app/components/experiment-wrapper.tsx
+++ b/src/mobile-app/components/experiment-wrapper.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { IExperiment, IExperimentData } from "../../shared/experiment-types";
+import { IExperiment, IExperimentConfig, IExperimentData } from "../../shared/experiment-types";
 import { Experiment } from "../../shared/components/experiment";
 import { Initials } from "../../shared/components/initials";
 
@@ -12,6 +12,13 @@ interface IProps {
   onDataChange: (data: IExperimentData) => void;
   onBackBtnClick: () => void;
 }
+
+// App specific config. Mobile app shouldn't show labels and it should use sensors.
+// LARA app will have different config.
+const experimentConfig: IExperimentConfig = {
+  hideLabels: true,
+  useSensors: true
+};
 
 export const ExperimentWrapper: React.FC<IProps> = ({ experiment, experimentIdx, data, onDataChange, onBackBtnClick }) => {
   const { metadata } = experiment;
@@ -31,7 +38,7 @@ export const ExperimentWrapper: React.FC<IProps> = ({ experiment, experimentIdx,
         </div>
       </div>
       <div className={css.workspace}>
-        <Experiment experiment={experiment} data={data} onDataChange={onDataChange}/>
+        <Experiment experiment={experiment} config={experimentConfig} data={data} onDataChange={onDataChange} />
       </div>
     </div>
   );

--- a/src/mobile-app/hooks/use-runs.ts
+++ b/src/mobile-app/hooks/use-runs.ts
@@ -1,4 +1,4 @@
-import { IExperiment, IExperimentData } from "../../shared/experiment-types";
+import { IExperiment, IExperimentData, initNewFormData } from "../../shared/experiment-types";
 import { useLocalStorage } from "./use-local-storage";
 import { useState } from "react";
 
@@ -33,7 +33,7 @@ export const useRuns = (): IUseRunsResult => {
     const newRun = {
       key: timestamp.toString(),
       experimentIdx,
-      data: { timestamp },
+      data: initNewFormData(experiment),
       experiment
     };
     // Update list of available runs.

--- a/src/mobile-app/hooks/use-sensor.ts
+++ b/src/mobile-app/hooks/use-sensor.ts
@@ -9,8 +9,15 @@ export interface IUseSensorResult {
   error: any | undefined;
 }
 
-export const useSensor = (sensor: Sensor) => {
-
+export const useSensor = (sensor: Sensor | null) => {
+  if (!sensor) {
+    return {
+      connected: false,
+      deviceName: undefined,
+      values: {},
+      error: undefined
+    };
+  }
   const {connected, deviceName, values} = sensor;
   const [useSensorResult, setUseSensorResult] = useState<IUseSensorResult>({connected, deviceName, values, error: undefined});
 

--- a/src/sensors/sensor.ts
+++ b/src/sensors/sensor.ts
@@ -6,7 +6,7 @@ export interface ISensorCapabilities {
   humidity?: boolean;
 }
 export type SensorCapabilityKey = keyof ISensorCapabilities;
-export const AllCapabilityKeys: SensorCapabilityKey[] = ["illuminance", "temperature", "humidity"]
+export const AllCapabilityKeys: SensorCapabilityKey[] = ["illuminance", "temperature", "humidity"];
 
 export interface ISensorValues {
   illuminance?: number;

--- a/src/shared/components/bootstrap-vortex-theme.scss
+++ b/src/shared/components/bootstrap-vortex-theme.scss
@@ -17,3 +17,12 @@
     box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(0, 0, 0, 0.25);
   }
 }
+
+// Hide array and object labels. They are impossible to hide using dataSchema or uiSchema unfortunately.
+// At this point it doesn't seem they'll be useful. Note that regular fields (string, number, etc.) will still
+// support labels.
+.field-array, .field-object {
+  & > label {
+    display: none;
+  }
+}

--- a/src/shared/components/bootstrap-vortex-theme.scss
+++ b/src/shared/components/bootstrap-vortex-theme.scss
@@ -26,3 +26,7 @@
     display: none;
   }
 }
+
+.field:first-child {
+  margin-top: 10px;
+}

--- a/src/shared/components/data-table-field.module.scss
+++ b/src/shared/components/data-table-field.module.scss
@@ -1,0 +1,5 @@
+@import "variables";
+
+.dataTable {
+
+}

--- a/src/shared/components/data-table-field.module.scss
+++ b/src/shared/components/data-table-field.module.scss
@@ -1,5 +1,88 @@
-@import "variables";
+$headerCol: #efefef;
+$tdCol: #fff;
 
 .dataTable {
+  .table {
+    width: 100%;
+    font-size: 14px;
+    font-weight: normal;
+    font-stretch: normal;
+    font-style: normal;
+    line-height: normal;
+    letter-spacing: 0.39px;
+    text-align: center;
+    table-layout: fixed;
 
+    td, th {
+      height: 42px;
+      border-style: solid;
+      border-width: 2px;
+    }
+    th, .readOnly {
+      background-color: $headerCol;
+      border-color: $tdCol;
+      text-align: center;
+    }
+    .active > .readOnly {
+      background-color: rgba(0, 233, 14, 0.2);
+    }
+    th:last-child {
+      border-right-color: $headerCol;
+    }
+    tr:last-child .readOnly {
+      border-bottom-color: $headerCol;
+    }
+    td {
+      border-color: $headerCol;
+    }
+    input {
+      border: none;
+      width: 100%;
+      height: 100%;
+      font-size: 22px;
+      font-weight: normal;
+      font-stretch: normal;
+      font-style: normal;
+      line-height: normal;
+      letter-spacing: 0.61px;
+      text-align: center;
+      color: #00c30b;
+    }
+
+    .recordSensorReading {
+      height: 28px;
+      border-radius: 14px;
+      background-color: #d9d9d9;
+      color: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0 5px;
+      &.active {
+        background-color: #00e90e;
+        &:hover {
+          cursor: pointer;
+        }
+      }
+    }
+
+    .refreshSensorReadingColumn {
+      width: 42px;
+    }
+
+    .refreshSensorReading {
+      height: 30px;
+      width: 30px;
+      border-radius: 15px;
+      background-color: #d9d9d9;
+      color: #fff;
+      margin: 0 auto;
+      &.active {
+        background-color: #00e90e;
+        &:hover {
+          cursor: pointer;
+        }
+      }
+    }
+  }
 }

--- a/src/shared/components/data-table-field.module.scss
+++ b/src/shared/components/data-table-field.module.scss
@@ -2,6 +2,13 @@ $headerCol: #efefef;
 $tdCol: #fff;
 
 .dataTable {
+  .title {
+    font-size: 18px;
+    font-weight: normal;
+    letter-spacing: 0.5px;
+    padding: 10px;
+  }
+
   .table {
     width: 100%;
     font-size: 14px;

--- a/src/shared/components/data-table-field.module.scss
+++ b/src/shared/components/data-table-field.module.scss
@@ -47,6 +47,9 @@ $tdCol: #fff;
       letter-spacing: 0.61px;
       text-align: center;
       color: #00c30b;
+      &:disabled {
+        opacity: 0.5;
+      }
     }
 
     .recordSensorReading {

--- a/src/shared/components/data-table-field.tsx
+++ b/src/shared/components/data-table-field.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { FieldProps } from "react-jsonschema-form";
+import css from "./data-table-field.module.scss";
+import { MockSensor } from "../../sensors/mock-sensor";
+import { AllCapabilities, Sensor } from "../../sensors/sensor";
+import { SensorComponent } from "../../mobile-app/components/sensor";
+import { IVortexFormContext } from "./form";
+import { getURLParam } from "../utils/get-url-param";
+import { DeviceSensor } from "../../sensors/device-sensor";
+
+const useMockSensor = getURLParam("mockSensor") || false;
+
+let sensorInstance: Sensor | null = null;
+const getSensor = () => {
+  if (!sensorInstance) {
+    if (useMockSensor) {
+      sensorInstance = new MockSensor({
+        capabilities: AllCapabilities,
+        pollInterval: 500,
+        deviceName: "Mocked Sensor"
+      });
+    } else {
+      sensorInstance = new DeviceSensor({
+        capabilities: AllCapabilities
+      });
+    }
+  }
+  return sensorInstance;
+};
+
+export const DataTableField: React.FC<FieldProps> = props => {
+  const formContext: IVortexFormContext = props.formContext;
+  const useSensors = formContext.experimentConfig.useSensors;
+  return (
+    <div className={css.dataTable}>
+      { useSensors && <SensorComponent sensor={getSensor()} />}
+    </div>
+  );
+};

--- a/src/shared/components/data-table-field.tsx
+++ b/src/shared/components/data-table-field.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { FieldProps } from "react-jsonschema-form";
 import css from "./data-table-field.module.scss";
 import { MockSensor } from "../../sensors/mock-sensor";
-import { AllCapabilities, Sensor, SensorCapabilityKey } from "../../sensors/sensor";
+import { ISensorCapabilities, SensorCapabilityKey } from "../../sensors/sensor";
 import { SensorComponent } from "../../mobile-app/components/sensor";
 import { IVortexFormContext } from "./form";
 import { getURLParam } from "../utils/get-url-param";
@@ -10,29 +10,77 @@ import { DeviceSensor } from "../../sensors/device-sensor";
 import { JSONSchema7 } from "json-schema";
 import { IFormUiSchema } from "../experiment-types";
 import { Icon } from "./icon";
-import { IUseSensorResult, useSensor } from "../../mobile-app/hooks/use-sensor";
+import { useSensor } from "../../mobile-app/hooks/use-sensor";
 
 const useMockSensor = getURLParam("mockSensor") || false;
 
-let sensorInstance: Sensor | null = null;
-const getSensor = () => {
-  if (!sensorInstance) {
-    if (useMockSensor) {
-      sensorInstance = new MockSensor({
-        capabilities: AllCapabilities,
-        pollInterval: 500,
-        deviceName: "Mocked Sensor"
-      });
-    } else {
-      sensorInstance = new DeviceSensor({
-        capabilities: AllCapabilities
-      });
+const defPrecision = 2;
+
+// Authors can provide special values in the initial form data. They will be dynamically evaluated.
+const fieldFunction: {[key: string]: (name: string, formData: IDataTableData) => number | undefined} = {
+  // average
+  "<AVG>": (name: string, formData: IDataTableData) => {
+    let sum = 0;
+    let count = 0;
+    formData.forEach(row => {
+      const value = Number(row[name]);
+      if (!isNaN(value)) {
+        sum += value;
+        count += 1;
+      }
+    });
+    if (count === 0) {
+      return undefined;
     }
+    return Number((sum / count).toFixed(defPrecision));
+  },
+  "<SUM>": (name: string, formData: IDataTableData) => {
+    let sum = 0;
+    let count = 0;
+    formData.forEach(row => {
+      const value = Number(row[name]);
+      if (!isNaN(value)) {
+        sum += value;
+        count += 1;
+      }
+    });
+    if (count === 0) {
+      return undefined;
+    }
+    return Number((sum).toFixed(defPrecision));
   }
-  return sensorInstance;
 };
 
-const validateSchema = (schema: JSONSchema7)  => {
+const isFunctionSymbol = (value: string) => {
+  return Object.keys(fieldFunction).indexOf(value) !== -1;
+};
+
+// Schema that is accepted by this component.
+interface IDataTableField {
+  type: "string" | "number";
+  title?: string;
+  readOnly?: boolean;
+}
+
+interface IDataTableDataSchema {
+  type: "array";
+  items: {
+    type: "object";
+    properties: {
+      [propName: string]: IDataTableField;
+    };
+  };
+}
+
+// Form data accepted by this component.
+interface IDataTableRow {
+  [propName: string]: string | number;
+}
+
+type IDataTableData = IDataTableRow[];
+
+// Validates if provided schema matches IDataTableDataSchema interface.
+const validateSchema = (schema: JSONSchema7): IDataTableDataSchema => {
   if (schema.type !== "array") {
     throw new Error("DataTableField requires array data type");
   }
@@ -43,12 +91,30 @@ const validateSchema = (schema: JSONSchema7)  => {
   ) {
     throw new Error("DataTableField requires array of objects data type");
   }
+  return schema as IDataTableDataSchema;
 };
 
-const isRowComplete = (row: {[k: string]: any}, tablePropNames: string[]) => {
+const getSensor = (sensorFields: string[]) => {
+  const capabilities: ISensorCapabilities = {};
+  sensorFields.forEach(fieldName => capabilities[fieldName as SensorCapabilityKey] = true);
+  if (useMockSensor) {
+    return new MockSensor({
+      capabilities,
+      autoConnect: true,
+      pollInterval: 500,
+      deviceName: "Mocked Sensor"
+    });
+  } else {
+    return new DeviceSensor({
+      capabilities
+    });
+  }
+};
+
+const isRowComplete = (row: { [k: string]: any }, fieldKeys: string[]) => {
   let result = true;
-  tablePropNames.forEach(name => {
-    if (row[name] === undefined) {
+  fieldKeys.forEach(name => {
+    if (row[name] === undefined || isFunctionSymbol(row[name])) {
       result = false;
     }
   });
@@ -57,92 +123,77 @@ const isRowComplete = (row: {[k: string]: any}, tablePropNames: string[]) => {
 
 export const DataTableField: React.FC<FieldProps> = props => {
   const { schema, onChange } = props;
-  const [formData, setFormData] = useState<any>(props.formData);
-
+  let validatedSchema = null;
+  try {
+    validatedSchema = validateSchema(schema as JSONSchema7);
+  } catch (e) {
+    return <div>{e.message}</div>;
+  }
+  const fieldDefinition = validatedSchema.items.properties;
+  let fieldKeys = Object.keys(fieldDefinition);
   // Cast some types to Vortex-specific types so it's easier to work with them in the code below.
   const formContext: IVortexFormContext = props.formContext;
   const uiSchema: IFormUiSchema = props.uiSchema as IFormUiSchema;
-  let sensorOutput: IUseSensorResult | null = null;
-  if (formContext.experimentConfig.useSensors) {
-    sensorOutput = useSensor(getSensor());
-  }
-
-  try {
-    validateSchema(schema as JSONSchema7);
-  } catch (e) {
-    return <div>{e.message}</div>
-  }
-  const tableDef = (schema.items as JSONSchema7).properties as {[k: string]: JSONSchema7};
-  let tablePropNames = Object.keys(tableDef);
-
-  const sensorProps = sensorOutput && uiSchema["ui:dataTableOptions"]?.sensorFields;
-  const nonSensorProps = sensorProps && tablePropNames.filter(name => sensorProps.indexOf(name) === -1);
-  if (sensorProps && nonSensorProps) {
+  const sensorFields = uiSchema["ui:dataTableOptions"]?.sensorFields || [];
+  const nonSensorFields = fieldKeys.filter(name => sensorFields.indexOf(name) === -1);
+  if (sensorFields && nonSensorFields) {
     // Change order of fields, so non-sensor fields are rendered first.
-    tablePropNames = nonSensorProps.concat(sensorProps);
+    fieldKeys = nonSensorFields.concat(sensorFields);
   }
+  const sensor = formContext.experimentConfig.useSensors ? getSensor(sensorFields) : null;
+  const sensorOutput = useSensor(sensor);
+  const [formData, setFormData] = useState<IDataTableData>(props.formData);
+  // Sensor buttons should be rendered only when sensor is available and some properties are connected to sensor.
+  const renderSensorButtons = sensor && sensorFields.length > 0;
 
   const handleInputChange = (rowIdx: number, propName: string, event: React.FormEvent<HTMLInputElement>) => {
-    // First update internal state, keep strings.
+    // First update internal state, keep strings here, casting to Numbers here can cause confusing changes of the input.
     let newData = formData.slice();
     const rawValue = event.currentTarget.value;
-    newData[rowIdx] = Object.assign({}, newData[rowIdx], {[propName]: rawValue});
+    newData[rowIdx] = Object.assign({}, newData[rowIdx], { [propName]: rawValue });
     setFormData(newData);
     // Then, notify parent component that data has changed. Try to cast to proper type if possible.
     newData = formData.slice();
-    const value = tableDef[propName].type === "number" && !isNaN(Number(rawValue)) ? Number(rawValue) : rawValue;
-    newData[rowIdx] = Object.assign({}, newData[rowIdx], {[propName]: value});
+    const value = fieldDefinition[propName].type === "number" && !isNaN(Number(rawValue)) ? Number(rawValue) : rawValue;
+    newData[rowIdx] = Object.assign({}, newData[rowIdx], { [propName]: value });
     onChange(newData);
   };
 
   const onSensorRecordClick = (rowIdx: number) => {
-    if (!sensorOutput || !sensorOutput.connected) {
+    if (!sensorOutput.connected) {
       alert("Sensor not connected");
       return;
     }
-    if (sensorProps) {
-      const values = sensorOutput.values;
-      const result: {[k: string]: number} = {};
-      sensorProps.forEach((name: SensorCapabilityKey) => {
-        if (!values[name]) {
-          alert(`Property ${name} is not supported by selected sensor`);
-        } else {
-          result[name] = Number(values[name]?.toFixed(3));
-        }
-      });
-      const newData = formData.slice();
-      newData[rowIdx] = Object.assign({}, newData[rowIdx], result);
-      setFormData(newData);
-      onChange(formData);
-    }
+    const values = sensorOutput.values;
+    const result: { [k: string]: number } = {};
+    sensorFields.forEach((name: SensorCapabilityKey) => {
+      if (!values[name]) {
+        alert(`Property ${name} is not supported by selected sensor`);
+      } else {
+        result[name] = Number(values[name]?.toFixed(defPrecision));
+      }
+    });
+    const newData = formData.slice();
+    newData[rowIdx] = Object.assign({}, newData[rowIdx], result);
+    setFormData(newData);
+    onChange(formData);
   };
 
-  const renderRowWithSensorSupport = (row: {[k: string]: any}, rowIdx: number) => {
-    if (!sensorProps || !nonSensorProps || !sensorOutput) {
-      return;
-    }
-
+  const renderRowWithSensorSupport = (row: { [k: string]: any }, rowIdx: number) => {
     // Record button should be rendered only on the initial run, when all the values are still undefined.
     // Once user uses this buttons and some values are saved, render normal table cells.
     let shouldRenderRecordBtn = true;
-    sensorProps.forEach((name: string) => {
+    sensorFields.forEach((name: string) => {
       if (row[name] !== undefined) {
         shouldRenderRecordBtn = false;
       }
     });
 
-    let cells: JSX.Element[] = [];
+    let cells: JSX.Element[] = renderBasicCells(nonSensorFields, row, rowIdx);
 
-    if (!shouldRenderRecordBtn) {
-      cells = renderRowWithoutSensorSupport(row, rowIdx);
-    } else {
-      const nonSensorCells = nonSensorProps.map(name =>
-        <td key={name} className={tableDef[name].readOnly ? css.readOnly : ""}>
-          { tableDef[name].readOnly ? row[name] : <input type="text" value={row[name]} /> }
-        </td>
-      );
+    if (shouldRenderRecordBtn) {
       const sensorConnected = sensorOutput.connected;
-      const recordSensorBtn = <td key="recordBtn" colSpan={sensorProps.length}>
+      const recordSensorBtn = <td key="recordBtn" colSpan={sensorFields.length}>
         <div
           className={css.recordSensorReading + ` ${sensorConnected ? css.active : ""}`}
           onClick={sensorConnected ? onSensorRecordClick.bind(null, rowIdx) : null}
@@ -150,45 +201,61 @@ export const DataTableField: React.FC<FieldProps> = props => {
           Record Sensor Reading
         </div>
       </td>;
-      cells = cells.concat(nonSensorCells).concat(recordSensorBtn);
+      cells = cells.concat(recordSensorBtn);
+    } else {
+      cells = cells.concat(renderBasicCells(sensorFields, row, rowIdx));
     }
     // Refresh button is active when record button isn't rendered anymore.
+    const anyNonFunctionSensorValues = sensorFields.map(name => row[name]).filter(value => !isFunctionSymbol(value)).length > 0;
     const refreshActive = sensorOutput.connected && !shouldRenderRecordBtn;
     const refreshBtn = <td key="refreshBtn" className={css.refreshSensorReadingColumn}>
-      <div
-        className={css.refreshSensorReading + ` ${refreshActive ? css.active : ""}`}
-        onClick={refreshActive ? onSensorRecordClick.bind(null, rowIdx) : null}
-      >
-        <Icon name="refresh" fill="#fff" />
-      </div>
+      {
+        anyNonFunctionSensorValues &&
+        <div
+          className={css.refreshSensorReading + ` ${refreshActive ? css.active : ""}`}
+          onClick={refreshActive ? onSensorRecordClick.bind(null, rowIdx) : null}
+        >
+          <Icon name="refresh" fill="#fff"/>
+        </div>
+      }
     </td>;
     return cells.concat(refreshBtn);
   };
 
-  const renderRowWithoutSensorSupport = (row: {[k: string]: any}, rowIdx: number) => {
-    return tablePropNames.map(name =>
-      <td key={name} className={tableDef[name].readOnly ? css.readOnly : ""}>
-        { tableDef[name].readOnly ? row[name] : <input type="text" value={row[name]} onChange={handleInputChange.bind(null, rowIdx, name)}/> }
+  const renderBasicCells = (fieldNames: string[], row: { [k: string]: any }, rowIdx: number) => {
+    return fieldNames.map(name => {
+      let value = row[name] || "";
+      const readOnly = fieldDefinition[name].readOnly;
+      let isFunction = false;
+      if (isFunctionSymbol(value)) {
+        value = fieldFunction[value](name, formData);
+        if (value === undefined) {
+          value = "--";
+        }
+        isFunction = true;
+      }
+      return <td key={name} className={readOnly ? css.readOnly : ""}>
+        {readOnly ? value : <input type="text" value={value} disabled={isFunction} onChange={handleInputChange.bind(null, rowIdx, name)}/>}
       </td>
-    );
+    });
   };
 
   return (
     <div className={css.dataTable}>
-      { sensorOutput && <SensorComponent sensor={getSensor()} />}
+      {sensor && <SensorComponent sensor={sensor}/>}
       <table className={css.table}>
         <tbody>
-          <tr>
-            {tablePropNames.map(name => <th key={name}>{tableDef[name].title || name}</th>)}
-            { sensorOutput && <th key="refreshCol" className={css.refreshSensorReadingColumn} />}
-          </tr>
-          {
-            formData.map((row: {[k: string]: any}, idx: number) =>
-              <tr key={idx} className={isRowComplete(row, tablePropNames) ? css.active : ""}>
-                { sensorOutput ? renderRowWithSensorSupport(row, idx) : renderRowWithoutSensorSupport(row, idx) }
-              </tr>
-            )
-          }
+        <tr>
+          {fieldKeys.map(name => <th key={name}>{fieldDefinition[name].title || name}</th>)}
+          {renderSensorButtons && <th key="refreshCol" className={css.refreshSensorReadingColumn}/>}
+        </tr>
+        {
+          formData.map((row: { [k: string]: any }, idx: number) =>
+            <tr key={idx} className={isRowComplete(row, fieldKeys) ? css.active : ""}>
+              {renderSensorButtons ? renderRowWithSensorSupport(row, idx) : renderBasicCells(nonSensorFields, row, idx)}
+            </tr>
+          )
+        }
         </tbody>
       </table>
     </div>

--- a/src/shared/components/data-table-field.tsx
+++ b/src/shared/components/data-table-field.tsx
@@ -1,12 +1,16 @@
-import React from "react";
+import React, { useState } from "react";
 import { FieldProps } from "react-jsonschema-form";
 import css from "./data-table-field.module.scss";
 import { MockSensor } from "../../sensors/mock-sensor";
-import { AllCapabilities, Sensor } from "../../sensors/sensor";
+import { AllCapabilities, Sensor, SensorCapabilityKey } from "../../sensors/sensor";
 import { SensorComponent } from "../../mobile-app/components/sensor";
 import { IVortexFormContext } from "./form";
 import { getURLParam } from "../utils/get-url-param";
 import { DeviceSensor } from "../../sensors/device-sensor";
+import { JSONSchema7 } from "json-schema";
+import { IFormUiSchema } from "../experiment-types";
+import { Icon } from "./icon";
+import { IUseSensorResult, useSensor } from "../../mobile-app/hooks/use-sensor";
 
 const useMockSensor = getURLParam("mockSensor") || false;
 
@@ -28,12 +32,165 @@ const getSensor = () => {
   return sensorInstance;
 };
 
+const validateSchema = (schema: JSONSchema7)  => {
+  if (schema.type !== "array") {
+    throw new Error("DataTableField requires array data type");
+  }
+  if (
+    typeof schema.items !== "object" ||
+    (schema.items as JSONSchema7).type !== "object" ||
+    typeof (schema.items as JSONSchema7).properties !== "object"
+  ) {
+    throw new Error("DataTableField requires array of objects data type");
+  }
+};
+
+const isRowComplete = (row: {[k: string]: any}, tablePropNames: string[]) => {
+  let result = true;
+  tablePropNames.forEach(name => {
+    if (row[name] === undefined) {
+      result = false;
+    }
+  });
+  return result;
+};
+
 export const DataTableField: React.FC<FieldProps> = props => {
+  const { schema, onChange } = props;
+  const [formData, setFormData] = useState<any>(props.formData);
+
+  // Cast some types to Vortex-specific types so it's easier to work with them in the code below.
   const formContext: IVortexFormContext = props.formContext;
-  const useSensors = formContext.experimentConfig.useSensors;
+  const uiSchema: IFormUiSchema = props.uiSchema as IFormUiSchema;
+  let sensorOutput: IUseSensorResult | null = null;
+  if (formContext.experimentConfig.useSensors) {
+    sensorOutput = useSensor(getSensor());
+  }
+
+  try {
+    validateSchema(schema as JSONSchema7);
+  } catch (e) {
+    return <div>{e.message}</div>
+  }
+  const tableDef = (schema.items as JSONSchema7).properties as {[k: string]: JSONSchema7};
+  let tablePropNames = Object.keys(tableDef);
+
+  const sensorProps = sensorOutput && uiSchema["ui:dataTableOptions"]?.sensorFields;
+  const nonSensorProps = sensorProps && tablePropNames.filter(name => sensorProps.indexOf(name) === -1);
+  if (sensorProps && nonSensorProps) {
+    // Change order of fields, so non-sensor fields are rendered first.
+    tablePropNames = nonSensorProps.concat(sensorProps);
+  }
+
+  const handleInputChange = (rowIdx: number, propName: string, event: React.FormEvent<HTMLInputElement>) => {
+    // First update internal state, keep strings.
+    let newData = formData.slice();
+    const rawValue = event.currentTarget.value;
+    newData[rowIdx] = Object.assign({}, newData[rowIdx], {[propName]: rawValue});
+    setFormData(newData);
+    // Then, notify parent component that data has changed. Try to cast to proper type if possible.
+    newData = formData.slice();
+    const value = tableDef[propName].type === "number" && !isNaN(Number(rawValue)) ? Number(rawValue) : rawValue;
+    newData[rowIdx] = Object.assign({}, newData[rowIdx], {[propName]: value});
+    onChange(newData);
+  };
+
+  const onSensorRecordClick = (rowIdx: number) => {
+    if (!sensorOutput || !sensorOutput.connected) {
+      alert("Sensor not connected");
+      return;
+    }
+    if (sensorProps) {
+      const values = sensorOutput.values;
+      const result: {[k: string]: number} = {};
+      sensorProps.forEach((name: SensorCapabilityKey) => {
+        if (!values[name]) {
+          alert(`Property ${name} is not supported by selected sensor`);
+        } else {
+          result[name] = Number(values[name]?.toFixed(3));
+        }
+      });
+      const newData = formData.slice();
+      newData[rowIdx] = Object.assign({}, newData[rowIdx], result);
+      setFormData(newData);
+      onChange(formData);
+    }
+  };
+
+  const renderRowWithSensorSupport = (row: {[k: string]: any}, rowIdx: number) => {
+    if (!sensorProps || !nonSensorProps || !sensorOutput) {
+      return;
+    }
+
+    // Record button should be rendered only on the initial run, when all the values are still undefined.
+    // Once user uses this buttons and some values are saved, render normal table cells.
+    let shouldRenderRecordBtn = true;
+    sensorProps.forEach((name: string) => {
+      if (row[name] !== undefined) {
+        shouldRenderRecordBtn = false;
+      }
+    });
+
+    let cells: JSX.Element[] = [];
+
+    if (!shouldRenderRecordBtn) {
+      cells = renderRowWithoutSensorSupport(row, rowIdx);
+    } else {
+      const nonSensorCells = nonSensorProps.map(name =>
+        <td key={name} className={tableDef[name].readOnly ? css.readOnly : ""}>
+          { tableDef[name].readOnly ? row[name] : <input type="text" value={row[name]} /> }
+        </td>
+      );
+      const sensorConnected = sensorOutput.connected;
+      const recordSensorBtn = <td key="recordBtn" colSpan={sensorProps.length}>
+        <div
+          className={css.recordSensorReading + ` ${sensorConnected ? css.active : ""}`}
+          onClick={sensorConnected ? onSensorRecordClick.bind(null, rowIdx) : null}
+        >
+          Record Sensor Reading
+        </div>
+      </td>;
+      cells = cells.concat(nonSensorCells).concat(recordSensorBtn);
+    }
+    // Refresh button is active when record button isn't rendered anymore.
+    const refreshActive = sensorOutput.connected && !shouldRenderRecordBtn;
+    const refreshBtn = <td key="refreshBtn" className={css.refreshSensorReadingColumn}>
+      <div
+        className={css.refreshSensorReading + ` ${refreshActive ? css.active : ""}`}
+        onClick={refreshActive ? onSensorRecordClick.bind(null, rowIdx) : null}
+      >
+        <Icon name="refresh" fill="#fff" />
+      </div>
+    </td>;
+    return cells.concat(refreshBtn);
+  };
+
+  const renderRowWithoutSensorSupport = (row: {[k: string]: any}, rowIdx: number) => {
+    return tablePropNames.map(name =>
+      <td key={name} className={tableDef[name].readOnly ? css.readOnly : ""}>
+        { tableDef[name].readOnly ? row[name] : <input type="text" value={row[name]} onChange={handleInputChange.bind(null, rowIdx, name)}/> }
+      </td>
+    );
+  };
+
   return (
     <div className={css.dataTable}>
-      { useSensors && <SensorComponent sensor={getSensor()} />}
+      { sensorOutput && <SensorComponent sensor={getSensor()} />}
+      <table className={css.table}>
+        <tbody>
+          <tr>
+            {tablePropNames.map(name => <th key={name}>{tableDef[name].title || name}</th>)}
+            { sensorOutput && <th key="refreshCol" className={css.refreshSensorReadingColumn} />}
+          </tr>
+          {
+            formData.map((row: {[k: string]: any}, idx: number) =>
+              <tr key={idx} className={isRowComplete(row, tablePropNames) ? css.active : ""}>
+                { sensorOutput ? renderRowWithSensorSupport(row, idx) : renderRowWithoutSensorSupport(row, idx) }
+              </tr>
+            )
+          }
+        </tbody>
+      </table>
     </div>
   );
 };

--- a/src/shared/components/data-table-field.tsx
+++ b/src/shared/components/data-table-field.tsx
@@ -142,6 +142,8 @@ export const DataTableField: React.FC<FieldProps> = props => {
   }
   const sensor = formContext.experimentConfig.useSensors ? getSensor(sensorFields) : null;
   const sensorOutput = useSensor(sensor);
+  const titleField = uiSchema["ui:dataTableOptions"]?.titleField;
+  const title = titleField && formContext.formData[titleField] || "";
   const [formData, setFormData] = useState<IDataTableData>(props.formData);
   // Sensor buttons should be rendered only when sensor is available and some properties are connected to sensor.
   const renderSensorButtons = sensor && sensorFields.length > 0;
@@ -243,6 +245,7 @@ export const DataTableField: React.FC<FieldProps> = props => {
   return (
     <div className={css.dataTable}>
       {sensor && <SensorComponent sensor={sensor}/>}
+      <div className={css.title}>{title}</div>
       <table className={css.table}>
         <tbody>
         <tr>

--- a/src/shared/components/experiment.tsx
+++ b/src/shared/components/experiment.tsx
@@ -2,16 +2,17 @@ import React from "react";
 import { useState } from "react";
 import { SectionButton } from "./section-button";
 import { Section } from "./section";
-import { ISection, IExperimentData, IExperiment } from "../experiment-types";
+import { ISection, IExperimentData, IExperiment, IExperimentConfig } from "../experiment-types";
 import css from "./experiment.module.scss";
 
 interface IProps {
   experiment: IExperiment;
   data?: IExperimentData;
   onDataChange?: (newData: IExperimentData) => void;
+  config: IExperimentConfig;
 }
 
-export const Experiment: React.FC<IProps> = ({ experiment, data, onDataChange }) => {
+export const Experiment: React.FC<IProps> = ({ experiment, data, onDataChange, config }) => {
   const { schema } = experiment;
   const { sections } = schema;
   const [section, setSection] = useState<ISection>(sections[0]);
@@ -43,6 +44,7 @@ export const Experiment: React.FC<IProps> = ({ experiment, data, onDataChange })
         <Section
           section={section}
           experiment={experiment}
+          experimentConfig={config}
           formData={currentData}
           onDataChange={onExperimentDataChange}
         />

--- a/src/shared/components/experiment.tsx
+++ b/src/shared/components/experiment.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useState } from "react";
 import { SectionButton } from "./section-button";
 import { Section } from "./section";
-import { ISection, IExperimentData, IExperiment, IExperimentConfig } from "../experiment-types";
+import { ISection, IExperimentData, IExperiment, IExperimentConfig, initNewFormData } from "../experiment-types";
 import css from "./experiment.module.scss";
 
 interface IProps {
@@ -16,7 +16,7 @@ export const Experiment: React.FC<IProps> = ({ experiment, data, onDataChange, c
   const { schema } = experiment;
   const { sections } = schema;
   const [section, setSection] = useState<ISection>(sections[0]);
-  const [currentData, setCurrentData] = useState<IExperimentData>(data || { timestamp: Date.now() });
+  const [currentData, setCurrentData] = useState<IExperimentData>(data || initNewFormData(experiment));
 
   const onExperimentDataChange = (newData: IExperimentData) => {
     setCurrentData(newData);

--- a/src/shared/components/field-template.module.scss
+++ b/src/shared/components/field-template.module.scss
@@ -1,3 +1,5 @@
+@import "variables";
+
 .iconAndField {
   display: flex;
   justify-content: space-between;
@@ -24,4 +26,8 @@
       padding-left: 60px;
     }
   }
+}
+
+.padding {
+  padding: 0 $inputPadding 0 $inputPadding;
 }

--- a/src/shared/components/field-template.tsx
+++ b/src/shared/components/field-template.tsx
@@ -2,13 +2,21 @@ import React from "react";
 import { FieldTemplateProps } from "react-jsonschema-form";
 import { Icon } from "./icon";
 import css from "./field-template.module.scss";
+import { IVortexFormContext } from "./form";
 
 export const FieldTemplate: React.FC<FieldTemplateProps> = props => {
-  const { id, classNames, label, help, required, description, children, displayLabel, uiSchema, formContext } = props;
+  const { id, classNames, label, help, required, description, children, displayLabel, schema, uiSchema } = props;
   const icon = uiSchema["ui:icon"];
+  const placeholder = uiSchema["ui:placeholder"];
+  // Don't add padding to array or wrapper objects. Add it only to the final fields (string, number, etc.).
+  const addPadding = schema.type !== "object" && schema.type !== "array";
+  const formContext: IVortexFormContext = props.formContext;
+  // Hide label when special option is enabled in form context and there's placeholder provided
+  // (otherwise, user would have no chances to identify form field).
+  const hideLabel = formContext.experimentConfig.hideLabels && placeholder;
   return (
-    <div className={classNames}>
-      { !formContext.hideLabels && <label htmlFor={id}>{label}</label> }
+    <div className={classNames + ` ${addPadding ? css.padding : ""}`}>
+      { !hideLabel && <label htmlFor={id}>{label}</label> }
       <div className={css.iconAndField}>
         {
           icon &&

--- a/src/shared/components/form.tsx
+++ b/src/shared/components/form.tsx
@@ -1,18 +1,21 @@
 import { withTheme } from 'react-jsonschema-form';
 import { FieldTemplate } from "./field-template";
+import { DataTableField } from "./data-table-field";
 // React JSON Schema uses Bootstrap semantics, so provide a bootstrap CSS and custom theme.
 import "./boostrap-3.3.7.scss";
 import "./bootstrap-vortex-theme.scss";
+import { IExperiment, IExperimentConfig, IExperimentData } from "../experiment-types";
 
-import React from "react";
+export interface IVortexFormContext {
+  experiment: IExperiment;
+  experimentConfig: IExperimentConfig;
+  formData: IExperimentData;
+}
 
 const VortexFormTheme = {
   FieldTemplate,
-  // Note that `hideLabels` is a custom context that is handled by `FieldTemplate`. We might need to make this
-  // option dynamic and e.g. hide them in mobile app but show in LARA. Client code can still overwrite context
-  // and provide custom values.
-  formContext: {
-    hideLabels: true
+  fields: {
+    dataTable: DataTableField
   }
 };
 

--- a/src/shared/components/icon.tsx
+++ b/src/shared/components/icon.tsx
@@ -5,6 +5,7 @@ import Assignment from "material-icons-svg/components/baseline/Assignment";
 import People from "material-icons-svg/components/baseline/People";
 import PhotoCamera from "material-icons-svg/components/baseline/PhotoCamera";
 import Comment from "material-icons-svg/components/baseline/Comment";
+import Refresh from "material-icons-svg/components/baseline/Refresh";
 
 // Use material icon names as a key, so it's easier to define these icons in form UI schema:
 // https://material.io/resources/icons/?style=baseline
@@ -14,7 +15,8 @@ const Icons: {[key: string]: any} = {
   assignment: Assignment,
   people: People,
   photo_camera: PhotoCamera,
-  comment: Comment
+  comment: Comment,
+  refresh: Refresh
 };
 
 interface IProps {

--- a/src/shared/components/metadata.module.scss
+++ b/src/shared/components/metadata.module.scss
@@ -1,6 +1,8 @@
 @import "variables";
 
 .metadata {
+  padding: $inputPadding;
+
   .main {
     display: flex;
     align-items: center;
@@ -19,7 +21,7 @@
 
   hr {
     margin-top: 25px;
-    margin-bottom: 20px;
+    margin-bottom: 0;
     border: solid 0.5px $fontColor;
   }
 }

--- a/src/shared/components/section.module.scss
+++ b/src/shared/components/section.module.scss
@@ -1,3 +1,2 @@
 .section {
-  padding: 20px;
 }

--- a/src/shared/components/section.test.tsx
+++ b/src/shared/components/section.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Section } from "./section";
 import { mount } from "enzyme";
 import Form from "react-jsonschema-form";
-import { IDataSchema, IExperiment } from "../experiment-types";
+import { IDataSchema, IExperiment, IExperimentConfig } from "../experiment-types";
 
 jest.mock("react-jsonschema-form");
 
@@ -30,7 +30,7 @@ describe("Section component", () => {
 
   it("immediately notifies parent when form is updated by the user", () => {
     const onDataChange = jest.fn();
-    const wrapper = mount(<Section experiment={experiment} section={section} formData={{timestamp: Date.now()}} onDataChange={onDataChange} />);
+    const wrapper = mount(<Section experiment={experiment} experimentConfig={{} as IExperimentConfig} section={section} formData={{timestamp: Date.now()}} onDataChange={onDataChange} />);
     const form = wrapper.find(Form).instance();
     expect(form).toBeDefined();
     const newData = { foo: "test" };

--- a/src/shared/components/section.tsx
+++ b/src/shared/components/section.tsx
@@ -5,10 +5,10 @@ import {
   IExperimentData,
   ISection,
   SectionComponentName,
-  SectionComponent
+  SectionComponent, IExperimentConfig
 } from "../experiment-types";
 import { IChangeEvent } from "react-jsonschema-form";
-import { Form } from "./form";
+import { Form, IVortexFormContext } from "./form";
 import { Metadata } from "./metadata";
 import css from "./section.module.scss";
 
@@ -17,13 +17,14 @@ interface IProps {
   experiment: IExperiment;
   formData: IExperimentData;
   onDataChange?: (newData: IExperimentData) => void;
+  experimentConfig: IExperimentConfig;
 }
 
 const SectionComponent: {[name in SectionComponentName]: SectionComponent} = {
   metadata: Metadata
 };
 
-export const Section: React.FC<IProps> = ({ section, experiment, formData, onDataChange }) => {
+export const Section: React.FC<IProps> = ({ section, experiment, formData, onDataChange, experimentConfig }) => {
   let formSchema: IDataSchema | null = null;
   if (section.formFields && section.formFields.length > 0) {
     const dataSchema = experiment.schema.dataSchema;
@@ -60,6 +61,12 @@ export const Section: React.FC<IProps> = ({ section, experiment, formData, onDat
           uiSchema={experiment.schema.formUiSchema}
           formData={formData}
           onChange={onChange}
+          formContext={{
+            experiment,
+            experimentConfig,
+            // Pass the whole form data again, so custom field can access other field values.
+            formData
+          } as IVortexFormContext}
         >
           {/* Children are used to render custom action buttons. We don't want any, */}
           {/* as form is saving and validating data live. */}

--- a/src/shared/components/variables.scss
+++ b/src/shared/components/variables.scss
@@ -5,4 +5,4 @@ $headerHeight: 60px;
 $headerIconSize: 40px;
 $headerIconMargin: ($headerHeight - $headerIconSize) / 2;
 
-
+$inputPadding: 20px;

--- a/src/shared/experiment-types.ts
+++ b/src/shared/experiment-types.ts
@@ -23,6 +23,8 @@ export interface IFormUiSchema extends UiSchema {
   "ui:dataTableOptions"?: {
     // List of properties that should be connected to sensor output.
     sensorFields?: string[];
+    // Reference to other form field that should be used as a table title.
+    titleField?: string;
   };
 }
 

--- a/src/shared/experiment-types.ts
+++ b/src/shared/experiment-types.ts
@@ -67,3 +67,8 @@ export interface ISectionComponentProps {
 }
 
 export type SectionComponent = React.FC<ISectionComponentProps>;
+
+export interface IExperimentConfig {
+  hideLabels: boolean;
+  useSensors: boolean;
+}

--- a/src/shared/experiment-types.ts
+++ b/src/shared/experiment-types.ts
@@ -67,7 +67,7 @@ export type IExperiment = IExperimentV1
 
 export interface IExperimentData {
   // This will be injected by ExperimentWrapper automatically on initial load.
-  timestamp: number;
+  timestamp?: number;
   // Other properties are unknown, they're specified by Experiment dataSchema.
   [name: string]: any;
 }

--- a/src/shared/experiment-types.ts
+++ b/src/shared/experiment-types.ts
@@ -1,6 +1,7 @@
 import { UiSchema } from "react-jsonschema-form";
+import { JSONSchema6 } from "json-schema";
 
-export interface IDataSchema {
+export interface IDataSchema extends JSONSchema6 {
   // Experiment data should have "object" type.
   type: "object";
   // Every property listed in `properties` list will be eventually rendered in one of the experiment sections.
@@ -8,11 +9,21 @@ export interface IDataSchema {
   required?: string[];
 }
 
+// Currently there's only one custom form field.
+export type CustomFieldName = "dataTable";
+
 export interface IFormUiSchema extends UiSchema {
   // Please see the docs: https://react-jsonschema-form.readthedocs.io/en/latest/form-customization/#the-uischema-object
-  // There's a custom extension of this format that lets you provide "ui:icon". Check Icon component to see list of
-  // all available icons or to add a new one.
+  // There's a custom extension of this format that lets you provide "ui:icon" to every field.
+  // Check Icon component to see list of all available icons or to add a new one.
   "ui:icon"?: "string";
+  "ui:field"?: CustomFieldName;
+  // Custom fields might add their field-specific options to "ui:options" object. For clarity, they should specify
+  // them under "ui:<fieldName>Options" key.
+  "ui:dataTableOptions"?: {
+    // List of properties that should be connected to sensor output.
+    sensorFields?: string[];
+  };
 }
 
 // For now there's only supported section component - "metadata". In the future, this list might grow.
@@ -49,6 +60,7 @@ export interface IExperimentV1 {
     initials: string;
   };
   schema: IExperimentSchema;
+  data?: IExperimentData;
 }
 
 export type IExperiment = IExperimentV1
@@ -59,6 +71,9 @@ export interface IExperimentData {
   // Other properties are unknown, they're specified by Experiment dataSchema.
   [name: string]: any;
 }
+
+// New data should be based on initial data provided in the experiment schema + timestamp.
+export const initNewFormData = (experiment: IExperiment) => Object.assign({}, experiment.data, { timestamp: Date.now() });
 
 // Custom components listed by sections should accept these properties.
 export interface ISectionComponentProps {

--- a/src/shared/index.html
+++ b/src/shared/index.html
@@ -10,7 +10,11 @@
   <body>
     <h2>Shared Components Demo Page</h2>
 
-    <h4>Experiment Component</h4>
+    <h4>WATERS Experiment</h4>
     <div class="demo" id="experiment-1"></div>
+    <h4>Data Table Example 1</h4>
+    <div class="demo" id="experiment-2"></div>
+    <h4>Data Table Example 2 (SUM function)</h4>
+    <div class="demo" id="experiment-3"></div>
   </body>
 </html>

--- a/src/shared/index.tsx
+++ b/src/shared/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { Experiment } from "./components/experiment";
-import { IExperiment, IExperimentV1 } from "./experiment-types";
+import { IExperiment } from "./experiment-types";
 import ExperimentJSONs from "../data/experiments.json";
 
 import "./index.sass";
@@ -38,13 +38,17 @@ const experiment2 = {
       {
         "title": "Measure",
         "icon": "settings_input_antenna",
-        "formFields": ["experimentData"]
+        "formFields": ["tableTitle", "experimentData"]
       }
     ],
     "dataSchema": {
       "type": "object",
       "required": ["studySite", "label"],
       "properties": {
+        "tableTitle": {
+          "title": "Title",
+          "type": "string"
+        },
         "experimentData": {
           "type": "array",
           "items": {
@@ -74,10 +78,14 @@ const experiment2 = {
       }
     },
     "formUiSchema": {
+      "tableTitle": {
+        "ui:placeholder": "Title"
+      },
       "experimentData": {
         "ui:field": "dataTable",
         "ui:dataTableOptions": {
-          "sensorFields": ["temperature", "illuminance"]
+          "sensorFields": ["temperature", "illuminance"],
+          "titleField": "tableTitle"
         }
       }
     }

--- a/src/shared/index.tsx
+++ b/src/shared/index.tsx
@@ -184,7 +184,7 @@ ReactDOM.render(
     />
     <h4>Experiment Schema JSON</h4>
     <pre>
-      {JSON.stringify(experiment2, null, 2)}
+      {JSON.stringify(experiment3, null, 2)}
     </pre>
   </>,
   document.getElementById("experiment-3")

--- a/src/shared/index.tsx
+++ b/src/shared/index.tsx
@@ -6,11 +6,17 @@ import ExperimentJSONs from "../data/experiments.json";
 
 import "./index.sass";
 
+const mobileAppConfig = {
+  hideLabels: true,
+  useSensors: true
+};
+
 const experiment = ExperimentJSONs[0] as IExperiment;
 ReactDOM.render(
   <>
     <Experiment
       experiment={experiment}
+      config={mobileAppConfig}
     />
     <h4>Experiment Schema JSON</h4>
     <pre>

--- a/src/shared/index.tsx
+++ b/src/shared/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { Experiment } from "./components/experiment";
-import { IExperiment } from "./experiment-types";
+import { IExperiment, IExperimentV1 } from "./experiment-types";
 import ExperimentJSONs from "../data/experiments.json";
 
 import "./index.sass";
@@ -11,17 +11,173 @@ const mobileAppConfig = {
   useSensors: true
 };
 
-const experiment = ExperimentJSONs[0] as IExperiment;
+const experiment1 = ExperimentJSONs[0] as IExperiment;
 ReactDOM.render(
   <>
     <Experiment
-      experiment={experiment}
+      experiment={experiment1}
       config={mobileAppConfig}
     />
     <h4>Experiment Schema JSON</h4>
     <pre>
-      {JSON.stringify(experiment, null, 2)}
+      {JSON.stringify(experiment1, null, 2)}
     </pre>
   </>,
   document.getElementById("experiment-1")
+);
+
+const experiment2 = {
+  "version": "1.0.0",
+  "metadata": {
+    "uuid": "e431af00-5ef9-44f8-a887-c76caa6ddde1",
+    "name": "Data Table Example",
+    "initials": "DT"
+  },
+  "schema": {
+    "sections": [
+      {
+        "title": "Measure",
+        "icon": "settings_input_antenna",
+        "formFields": ["experimentData"]
+      }
+    ],
+    "dataSchema": {
+      "type": "object",
+      "required": ["studySite", "label"],
+      "properties": {
+        "experimentData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["location"],
+            "properties": {
+              "location": {
+                "title": "Location",
+                "type": "string",
+                "readOnly": true
+              },
+              "comment": {
+                "title": "Comment",
+                "type": "string"
+              },
+              "temperature": {
+                "title": "Temperature (°C)",
+                "type": "number"
+              },
+              "illuminance": {
+                "title": "Illuminance (lux)",
+                "type": "number"
+              }
+            }
+          }
+        }
+      }
+    },
+    "formUiSchema": {
+      "experimentData": {
+        "ui:field": "dataTable",
+        "ui:dataTableOptions": {
+          "sensorFields": ["temperature", "illuminance"]
+        }
+      }
+    }
+  },
+  "data": {
+    "experimentData": [
+      {"location": "Corner 1"},
+      {"location": "Corner 2"},
+      {"location": "Corner 3"},
+      {"location": "Corner 4"},
+      {"location": "Average", "temperature":  "<AVG>", "illuminance": "<AVG>"}
+    ]
+  }
+} as IExperiment;
+ReactDOM.render(
+  <>
+    <Experiment
+      experiment={experiment2}
+      config={mobileAppConfig}
+    />
+    <h4>Experiment Schema JSON</h4>
+    <pre>
+      {JSON.stringify(experiment2, null, 2)}
+    </pre>
+  </>,
+  document.getElementById("experiment-2")
+);
+
+const experiment3 = {
+  "version": "1.0.0",
+  "metadata": {
+    "uuid": "e431af00-5ef9-44f8-a887-c76caa6ddde1",
+    "name": "Data Table Example",
+    "initials": "DT"
+  },
+  "schema": {
+    "sections": [
+      {
+        "title": "Measure",
+        "icon": "settings_input_antenna",
+        "formFields": ["experimentData"]
+      }
+    ],
+    "dataSchema": {
+      "type": "object",
+      "required": ["studySite", "label"],
+      "properties": {
+        "experimentData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["location"],
+            "properties": {
+              "location": {
+                "title": "Location",
+                "type": "string",
+                "readOnly": true
+              },
+              "trees": {
+                "title": "Trees Count",
+                "type": "number"
+              },
+              "temperature": {
+                "title": "Temperature (°C)",
+                "type": "number"
+              }
+            }
+          }
+        }
+      }
+    },
+    "formUiSchema": {
+      "experimentData": {
+        "ui:field": "dataTable",
+        "ui:dataTableOptions": {
+          "sensorFields": ["temperature"]
+        }
+      }
+    }
+  },
+  "data": {
+    "experimentData": [
+      {"location": "Sum / Average", "trees": "<SUM>", "temperature":  "<AVG>"},
+      {"location": "Corner 1"},
+      {"location": "Corner 2"},
+      {"location": "Corner 3"},
+      {"location": "Corner 4"}
+    ]
+  }
+} as IExperiment;
+ReactDOM.render(
+  <>
+    <Experiment
+      experiment={experiment3}
+      config={mobileAppConfig}
+    />
+    <h4>Experiment Schema JSON</h4>
+    <pre>
+      {JSON.stringify(experiment2, null, 2)}
+    </pre>
+  </>,
+  document.getElementById("experiment-3")
 );

--- a/src/shared/utils/format-time.ts
+++ b/src/shared/utils/format-time.ts
@@ -8,4 +8,4 @@ const dateOptions: Intl.DateTimeFormatOptions = {
   hour12: true
 };
 
-export const formatTime = (timestamp: number) => new Date(timestamp).toLocaleString("en-US", dateOptions);
+export const formatTime = (timestamp: number | undefined) => timestamp ? new Date(timestamp).toLocaleString("en-US", dateOptions) : "";

--- a/src/shared/utils/get-url-param.ts
+++ b/src/shared/utils/get-url-param.ts
@@ -1,0 +1,9 @@
+export const getURLParam = (name: string) => {
+  const url = (self || window).location.href;
+  name = name.replace(/[[]]/g, "\\$&");
+  const regex = new RegExp(`[?&]${name}(=([^&#]*)|&|#|$)`);
+  const results = regex.exec(url);
+  if (!results) return null;
+  if (!results[2]) return true;
+  return decodeURIComponent(results[2].replace(/\+/g, " "));
+};


### PR DESCRIPTION
Some UI elements (average) and tests are missing, but I guess there's enough progress to take a look and check if the direction is right.

@scytacki, I've changed the data table schema. Instead of the object of arrays, now we have an array of objects. That turned out to be easier to work with. Also, if we don't use our custom dataTable component, UI provided by React JSONSchema Form is very similar to what you proposed as a simplified view.

LARA app will be able to disable sensor support using `experimentConfig` that has been just added to the `Experiment` component.

`?mockSensor` URL param can be used to use MockedSensor for a demo or test purposes.

Demo: 
https://models-resources.concord.org/vortex/branch/data-table/mobile-app/index.html
Demo with Mocked Sensor: 
https://models-resources.concord.org/vortex/branch/data-table/mobile-app/index.html?mockSensor