### PR TITLE
Changed exact test time measurements to be within 10% tolerance

### DIFF
--- a/src/shared/utils/delay-promise.test.ts
+++ b/src/shared/utils/delay-promise.test.ts
@@ -7,6 +7,7 @@ describe("delayPromise", () => {
     const result = await delayPromise(delay, "foo");
     const after = Date.now();
     expect(result).toBe("foo");
-    expect(after - before).toBeGreaterThanOrEqual(delay);
+    // don't text exact time but +/- 10%
+    expect(after - before).toBeGreaterThanOrEqual(delay - (delay * 0.1));
   });
 });

--- a/src/shared/utils/serialize-promises.test.ts
+++ b/src/shared/utils/serialize-promises.test.ts
@@ -14,6 +14,8 @@ describe("serializePromises", () => {
     const serialize = await serializePromises([Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)], delay);
     const after = Date.now();
     expect(serialize).toEqual([1, 2, 3]);
-    expect(after - before).toBeGreaterThanOrEqual(delay * serialize.length);
+    // don't text exact time but +/- 10%
+    const duration = delay * serialize.length;
+    expect(after - before).toBeGreaterThanOrEqual(duration - (duration * 0.1));
   });
 });


### PR DESCRIPTION
Before this change we would get random test failures because the time measurment was off by 1ms.