### PR TITLE
iOS TestFlight additions

### DIFF
--- a/src/cordova-wrapper/config.xml
+++ b/src/cordova-wrapper/config.xml
@@ -23,10 +23,11 @@
 			<uses-permission android:name="android.permission.BLUETOOTH" />
 			<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
 			<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-		</config-file>        
+		</config-file>
     </platform>
     <platform name="ios">
         <allow-intent href="itms:*" />
         <allow-intent href="itms-apps:*" />
+        <preference name="WKWebViewOnly" value="true" />
     </platform>
 </widget>

--- a/src/cordova-wrapper/package-lock.json
+++ b/src/cordova-wrapper/package-lock.json
@@ -867,6 +867,11 @@
       "resolved": "https://registry.npmjs.org/cordova-plugin-compat/-/cordova-plugin-compat-1.2.0.tgz",
       "integrity": "sha1-C8ZXVyduvZIMASzpIOJ0F3V2Nz4="
     },
+    "cordova-plugin-ionic-webview": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-ionic-webview/-/cordova-plugin-ionic-webview-4.1.3.tgz",
+      "integrity": "sha512-hlrUF0kLjjEkZmpYlLJO0NnXmVjMmQ3MOZVXm1ytDihLPKHklYCOpCvjA5Wz3hJrPD1shFEsqi/SPnp873AsdQ=="
+    },
     "cordova-plugin-webbluetooth": {
       "version": "git+https://github.com/concord-consortium/cordova-plugin-webbluetooth.git#fc8de00a3c40ac5db7e861c304ab4441bbd2c5a9",
       "from": "git+https://github.com/concord-consortium/cordova-plugin-webbluetooth.git"

--- a/src/cordova-wrapper/package.json
+++ b/src/cordova-wrapper/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "cordova": "cordova",
     "run:browser": "cordova run browser",
-    "run:android": "cordova run android",
+    "run:android": "cordova run android --emulator",
     "run:android:device": "cordova run android --device"
   },
   "devDependencies": {
@@ -17,6 +17,9 @@
       },
       "cordova-plugin-webbluetooth": {
         "BLUETOOTH_USAGE_DESCRIPTION": "Scans for peripherals and enables interactions with associated devices"
+      },
+      "cordova-plugin-ionic-webview": {
+        "ANDROID_SUPPORT_ANNOTATIONS_VERSION": "27.+"
       }
     },
     "platforms": [
@@ -32,6 +35,7 @@
     "cordova-ios": "^5.1.1",
     "cordova-plugin-ble": "^2.0.1",
     "cordova-plugin-compat": "^1.2.0",
+    "cordova-plugin-ionic-webview": "^4.1.3",
     "cordova-plugin-webbluetooth": "git+https://github.com/concord-consortium/cordova-plugin-webbluetooth.git"
   }
 }


### PR DESCRIPTION
This PR includes a couple of small changes required to get the app on TestFlight without errors or warnings, [#171332364]. I branched off the dev branch, so until that PR is merged this one is a little bloated. All the changes here are in commit f9c66b5

Also needed the following settings added to the generated Vortex-info.plist, I wasn't able to get this information to populate the plist file automatically from other sources:

	<key>NSPhotoLibraryUsageDescription</key>
	<string>Camera access is required to photograph data collection sites and also to scan a QR code to upload data back to the classroom activity.</string>
	<key>NSBluetoothPeripheralUsageDescription</key>
	<string>This application uses bluetooth to find, connect and transfer data from Sensor Tag bluetooth devices</string>

Also needed one edit to ios.json in cordova-wrapper/platforms/ios to force Cordova to dump the old UIWebView and use WKWebView instead: 

   "config_munge": {
    "files": {
      "config.xml": {
        "parents": {
          "/*": [
            {
              "xml": "<preference name=\"WKWebViewOnly\" value=\"true\" />",
              "count": 1
            },