### PR TITLE
Use the humidity sensors ambient temperature

### DIFF
--- a/src/sensors/devices/sensor-tag-cc2650.ts
+++ b/src/sensors/devices/sensor-tag-cc2650.ts
@@ -1,9 +1,6 @@
 import { ISensorCapabilities } from "../sensor";
 import { BaseSensorTagDevice } from "./base-sensor-tag";
 
-// http://processors.wiki.ti.com/index.php/CC2650_SensorTag_User%27s_Guide
-const IR_SCALE_LSB = 0.03125;
-
 export class SensorTag2Device extends BaseSensorTagDevice {
 
   constructor(requestedCapabilities: ISensorCapabilities) {
@@ -42,12 +39,12 @@ export class SensorTag2Device extends BaseSensorTagDevice {
           }
         },
         temperature: {
-          service: "f000aa00-0451-4000-b000-000000000000",
-          data: "f000aa01-0451-4000-b000-000000000000", // ObjectLSB:ObjectMSB:AmbientLSB:AmbientMSB
-          characteristic: "f000aa02-0451-4000-b000-000000000000",
+          service: "f000aa20-0451-4000-b000-000000000000",
+          data: "f000aa21-0451-4000-b000-000000000000", // ObjectLSB:ObjectMSB:AmbientLSB:AmbientMSB
+          characteristic: "f000aa22-0451-4000-b000-000000000000",
           convert: (dataView: DataView) => {
-            const rawTemp = dataView.getUint16(2, true);
-            return (rawTemp >> 2) * IR_SCALE_LSB;
+            const rawTemp = dataView.getInt16(0, true);
+            return (rawTemp / 65536)*165 - 40;
           }
         }
       }


### PR DESCRIPTION
Some version of the CC2650 don't have an IR sensor
so they wouldn't have an ambient temperature on the IR sensor.

We could merge the CC1350 and the CC2650 into one, but it might be useful to
keep them separate to support other differences in the future.