### PR TITLE
Fix sensor disconnect/re-connect [#171524472]

### DIFF
--- a/src/mobile-app/components/sensor.tsx
+++ b/src/mobile-app/components/sensor.tsx
@@ -28,9 +28,9 @@ export const SensorComponent: React.FC<IProps> = ({sensor, onResetAll, onSetMode
   const [connecting, setConnecting] = useState(false);
 
   const handleConnectPromise = (isConnecting: boolean, handler: () => Promise<void>) => {
+    sensor.setError(undefined);
     setConnecting(isConnecting);
     handler()
-      .then(() => sensor.setError(undefined))
       .catch(err => sensor.setError(err))
       .finally(() => setConnecting(false));
   };

--- a/src/sensors/device-sensor.ts
+++ b/src/sensors/device-sensor.ts
@@ -73,13 +73,8 @@ export class DeviceSensor extends Sensor {
   }
 
   public disconnect(): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      if (!this.bluetoothDevice || !this.bluetoothDevice.gatt || !this.bluetoothDevice.gatt.connected) {
-        return reject("Not connected to a device");
-      }
-      this.bluetoothDevice.gatt.disconnect();
-      return resolve();
-    });
+    this.setConnected({connected: false});
+    return Promise.resolve();
   }
 
   protected pollValues(options: IPollOptions): Promise<ISensorValues> {
@@ -105,9 +100,7 @@ export class DeviceSensor extends Sensor {
     super.setConnected(options);
     if (!options.connected) {
       this.bluetoothDevice?.removeEventListener("gattserverdisconnected", this.handleDisconnected);
-      if (this.bluetoothDevice?.gatt?.connected) {
-        this.bluetoothDevice.gatt.disconnect();
-      }
+      this.bluetoothDevice?.gatt?.disconnect();
       this.device = undefined;
       this.bluetoothDevice = undefined;
       this.bluetoothServer = undefined;


### PR DESCRIPTION
This fixes three issues:

1. It clears the error message before connecting so that the "Connecting..." message shows if there was an existing error (such as timing out before connecting)
2. It removes the immediate BLE disconnect and instead uses the existing codepath to perform the disconnect after the final poll is done to get the values.
3. It performs the disconnect without checking for an existing connection to ensure we are disconnected.