### PR TITLE
Change alert/confirm titles to "Data Collector" [#171550615]

### DIFF
--- a/src/cordova-wrapper/package-lock.json
+++ b/src/cordova-wrapper/package-lock.json
@@ -867,13 +867,18 @@
       "resolved": "https://registry.npmjs.org/cordova-plugin-compat/-/cordova-plugin-compat-1.2.0.tgz",
       "integrity": "sha1-C8ZXVyduvZIMASzpIOJ0F3V2Nz4="
     },
+    "cordova-plugin-dialogs": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-dialogs/-/cordova-plugin-dialogs-2.0.2.tgz",
+      "integrity": "sha512-FUHI6eEVeoz2VkxbF0P56QlUQLGzXcvw3i4xuXyM9gEct6Y+FA3Xzgl2pJTZcTg5wRqLWzN08kgNoHPkom15pw=="
+    },
     "cordova-plugin-ionic-webview": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/cordova-plugin-ionic-webview/-/cordova-plugin-ionic-webview-4.1.3.tgz",
       "integrity": "sha512-hlrUF0kLjjEkZmpYlLJO0NnXmVjMmQ3MOZVXm1ytDihLPKHklYCOpCvjA5Wz3hJrPD1shFEsqi/SPnp873AsdQ=="
     },
     "cordova-plugin-webbluetooth": {
-      "version": "git+https://github.com/concord-consortium/cordova-plugin-webbluetooth.git#fc8de00a3c40ac5db7e861c304ab4441bbd2c5a9",
+      "version": "git+https://github.com/concord-consortium/cordova-plugin-webbluetooth.git#74541628b329dcd1072cac7c13fda650c84fc387",
       "from": "git+https://github.com/concord-consortium/cordova-plugin-webbluetooth.git"
     },
     "cordova-plugin-whitelist": {

--- a/src/cordova-wrapper/package.json
+++ b/src/cordova-wrapper/package.json
@@ -20,7 +20,8 @@
       },
       "cordova-plugin-ionic-webview": {
         "ANDROID_SUPPORT_ANNOTATIONS_VERSION": "27.+"
-      }
+      },
+      "cordova-plugin-dialogs": {}
     },
     "platforms": [
       "android",
@@ -35,6 +36,7 @@
     "cordova-ios": "^5.1.1",
     "cordova-plugin-ble": "^2.0.1",
     "cordova-plugin-compat": "^1.2.0",
+    "cordova-plugin-dialogs": "^2.0.2",
     "cordova-plugin-ionic-webview": "^4.1.3",
     "cordova-plugin-webbluetooth": "git+https://github.com/concord-consortium/cordova-plugin-webbluetooth.git"
   }

--- a/src/mobile-app/components/app.tsx
+++ b/src/mobile-app/components/app.tsx
@@ -5,6 +5,7 @@ import { RunPicker } from "./run-picker";
 import { useRuns, IRun } from "../hooks/use-runs";
 import { Uploader } from "./uploader";
 import { getURLParam } from "../../shared/utils/get-url-param";
+import { confirm } from "../../shared/utils/dialogs";
 
 import css from "./app.module.scss";
 
@@ -18,9 +19,9 @@ export const AppComponent: React.FC = () => {
   const allowReset = getURLParam("allowReset") || false;
 
   const handleDeleteRun = (run: IRun) => {
-    if (confirm(`Delete ${run.experiment.metadata.name} #${run.experimentIdx}?`)) {
+    confirm(`Delete ${run.experiment.metadata.name} #${run.experimentIdx}?`, () => {
       deleteRun(run);
-    }
+    });
   };
 
   const handleUpload = () => setUploadRun(activeRun || undefined);

--- a/src/shared/components/photo-or-note-field.tsx
+++ b/src/shared/components/photo-or-note-field.tsx
@@ -6,6 +6,7 @@ import { spinnerUrl } from "./spinner";
 import { Icon } from "./icon";
 import { MenuComponent, MenuItemComponent } from "./menu";
 import { Camera } from "../../mobile-app/components/camera";
+import { alert } from "../utils/dialogs";
 
 import css from "./photo-or-note-field.module.scss";
 

--- a/src/shared/utils/dialogs.ts
+++ b/src/shared/utils/dialogs.ts
@@ -1,0 +1,29 @@
+const win = window as any;
+
+const DialogTitle = "Data Collector";
+
+export const confirm = (message: string, onOk: () => void, onCancel?: () => void) => {
+  if (win.navigator.notification) {
+    win.navigator.notification.confirm(message, (button: number) => {
+      if (button === 1) {
+        onOk();
+      } else {
+        onCancel?.();
+      }
+    }, DialogTitle);
+  } else {
+    if (window.confirm(message)) {
+      onOk();
+    } else {
+      onCancel?.();
+    }
+  }
+};
+
+export const alert = (message: string) => {
+  if (win.navigator.notification) {
+    win.navigator.notification.alert(message, () => undefined, DialogTitle);
+  } else {
+    window.alert(message);
+  }
+};

--- a/tslint.json
+++ b/tslint.json
@@ -3,7 +3,8 @@
   "linterOptions": {
       "exclude": [
           "node_modules/**",
-          "src/cordova-wrapper/node_modules/**"
+          "src/cordova-wrapper/node_modules/**",
+          "src/cordova-wrapper/plugins/**"
       ]
   },
   "rules": {


### PR DESCRIPTION
To avoid renaming the iOS app the Cordova dialog plugin is used to set the title.  This does cause some extra code changes as that plugin uses callbacks instead of blocking and returning true/false on confirm.