### PR TITLE
Fixed unicode encoding issue with degree symbol [#171607986]

### DIFF
--- a/src/cordova-app/index.html
+++ b/src/cordova-app/index.html
@@ -28,6 +28,7 @@
         * Disables use of inline scripts in order to mitigate risk of XSS vulnerabilities. To change this:
             * Enable inline JS: add 'unsafe-inline' to default-src
     -->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com 'unsafe-eval'; style-src 'self' 'unsafe-inline'; media-src *; img-src 'self' data: content:; connect-src 'self' *">
     <meta name="format-detection" content="telephone=no">
     <meta name="msapplication-tap-highlight" content="no">

--- a/src/data/experiments.json
+++ b/src/data/experiments.json
@@ -77,7 +77,7 @@
                   "readOnly": true
                 },
                 "temperature": {
-                  "title": "Temperature (C)",
+                  "title": "Temperature (\u00B0C)",
                   "type": "number"
                 },
                 "illuminance": {


### PR DESCRIPTION
Set the Cordova app index.html to use UTF-8 and added degree symbol back to Schoolyard Investigation.