### PR TITLE
Fixed closing menu if clicked outside of menu [#171607882]

### DIFF
--- a/src/shared/components/menu.tsx
+++ b/src/shared/components/menu.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { Icon } from "./icon";
 import css from "./menu.module.scss";
 
@@ -17,11 +17,35 @@ export const MenuItemComponent: React.FC<IMenuItemProps> = ({onClick, icon, chil
 };
 
 export const MenuComponent: React.FC = (props) => {
+  // need to use both a state variable and a ref variable to hold showing status
+  // the state variable change triggers the re-render and the ref variable
+  // is available in the global handleClick() handler (the state variable would
+  // be captured in the handler's closure and always be the initial value of false)
   const [showMenu, setShowMenu] = useState(false);
+  const showingMenu = useRef(false);
+
+  const updateMenu = (showing: boolean) => {
+    setShowMenu(showing);
+    showingMenu.current = showing;
+  }
+
+  // hide the menu if a click is made outside the menu while it is showing
+  // this is not called if handleMenuIcon() is called as it stops
+  // propagation of the mouse event up to the window element
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (showingMenu.current) {
+        updateMenu(false);
+      }
+    };
+    window.addEventListener("click", handleClick);
+    return () => window.removeEventListener("click", handleClick);
+  }, []);
 
   const handleMenuIcon = (e: React.MouseEvent<HTMLDivElement>) => {
+    // stop handleClick() handler above from running
     e.stopPropagation();
-    setShowMenu(!showMenu);
+    updateMenu(!showMenu);
   };
 
   const renderMenu = () => {

--- a/src/shared/components/menu.tsx
+++ b/src/shared/components/menu.tsx
@@ -27,7 +27,7 @@ export const MenuComponent: React.FC = (props) => {
   const updateMenu = (showing: boolean) => {
     setShowMenu(showing);
     showingMenu.current = showing;
-  }
+  };
 
   // hide the menu if a click is made outside the menu while it is showing
   // this is not called if handleMenuIcon() is called as it stops


### PR DESCRIPTION
Adds a global click handler that closes the menu if it is showing.