### PR TITLE
Added listen for prop changes to notes/photos [#171084232]

### DIFF
--- a/src/shared/components/photo-or-note-field.tsx
+++ b/src/shared/components/photo-or-note-field.tsx
@@ -211,6 +211,11 @@ export const PhotoOrNoteField: React.FC<FieldProps> = props => {
     }
   }, []);
 
+  // listen for prop changes from uploads
+  useEffect(() => {
+    setFormData(props.formData);
+  }, [props.formData]);
+
   // get the initial window info and listen for resize/re-orientation
   // useEffect(() => {
   //   const updateWindowInfo = () => setWindowInfo({width: window.innerWidth, height: window.innerHeight});


### PR DESCRIPTION
This ensures that uploads change the notes/photos field if they are focused when the upload happens.

Currently, because of a UI change, it isn't possible to upload while in the notes field but it may be possible in the future.