### PR TITLE
Add dropdown datatype [#171289767]

### DIFF
--- a/src/shared/components/data-table-field.module.scss
+++ b/src/shared/components/data-table-field.module.scss
@@ -72,7 +72,7 @@ $headerBorder: #fff;
         background-color: $ccGray;
       }
     }
-    input {
+    input, select {
       border: none;
       width: 100%;
       height: 100%;
@@ -82,7 +82,7 @@ $headerBorder: #fff;
         border: solid 2px $ccTeal;
       }
     }
-    input[disabled] {
+    input[disabled], select[disabled] {
       opacity: 1;
     }
     .refreshSensorReadingColumn {

--- a/src/shared/components/data-table-field.test.tsx
+++ b/src/shared/components/data-table-field.test.tsx
@@ -479,4 +479,29 @@ describe("DataTableField component", () => {
     expect(res.stdDev).toEqual(5);
     expect(res.median).toEqual(10);
   });
+
+  it("handles dropdown definitions", () => {
+    const schema: JSONSchema7 = {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "dropdown": {
+            "title": "Dropdown",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["One", "Two", "Three"]
+            }
+          }
+        }
+      }
+    };
+
+    const formData = [{dropdown: ""}];
+    const wrapper = shallow(<DataTableField {...defProps} schema={schema as JSONSchema6} formData={formData} />);
+    expect(wrapper.find("option").length).toBe(4);
+    expect(wrapper.find("option").map(option => option.props().value)).toStrictEqual(["", "One", "Two", "Three"]);
+    expect(wrapper.find("select").props().value).toBe("");
+  });
 });

--- a/src/shared/index.html
+++ b/src/shared/index.html
@@ -16,5 +16,7 @@
     <div class="demo" id="experiment-2"></div>
     <h4>Data Table Example 2 (SUM function)</h4>
     <div class="demo" id="experiment-3"></div>
+    <h4>Data Table Example 3 (dropdown)</h4>
+    <div class="demo" id="experiment-4"></div>
   </body>
 </html>

--- a/src/shared/index.sass
+++ b/src/shared/index.sass
@@ -11,3 +11,11 @@ body
 .demo
   padding: 5px
   border: 1px solid gray
+
+.expando-title
+  font-weight: bold
+  text-align: center
+
+h4
+  font-weight: bold
+  margin: 20px 0 10px 0

--- a/src/shared/index.tsx
+++ b/src/shared/index.tsx
@@ -211,4 +211,78 @@ ReactDOM.render(
   document.getElementById("experiment-3")
 );
 
-
+const experiment4 = {
+  "version": "1.0.0",
+  "metadata": {
+    "uuid": "e431af00-5ef9-44f8-a887-c76caa6ddde1",
+    "name": "Data Table Example",
+    "initials": "DT"
+  },
+  "schema": {
+    "sections": [
+      {
+        "title": "Collect",
+        "icon": "collect",
+        "formFields": ["experimentData"]
+      }
+    ],
+    "dataSchema": {
+      "type": "object",
+      "required": ["studySite", "label"],
+      "properties": {
+        "experimentData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [],
+            "properties": {
+              "location": {
+                "title": "Location",
+                "type": "string",
+                "readOnly": true
+              },
+              "trees": {
+                "title": "Tree Count",
+                "type": "number"
+              },
+              "leafColor": {
+                "title": "Leaf Color",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": ["Green", "Orange", "Red"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "formUiSchema": {
+      "experimentData": {
+        "ui:field": "dataTable",
+        "ui:dataTableOptions": {
+          "sensorFields": []
+        }
+      }
+    }
+  },
+  "data": {
+    "experimentData": [
+      {"location": "Corner 1"},
+      {"location": "Corner 2"},
+      {"location": "Corner 3"},
+      {"location": "Corner 4"}
+    ]
+  }
+} as IExperiment;
+ReactDOM.render(
+  <>
+    <Experiment
+      experiment={experiment4}
+      config={mobileAppConfig}
+    />
+    <ExpandoSchema experiment={experiment4} />
+  </>,
+  document.getElementById("experiment-4")
+);

--- a/src/shared/index.tsx
+++ b/src/shared/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import ReactDOM from "react-dom";
 import { Experiment } from "./components/experiment";
 import { IExperiment, IExperimentConfig } from "./experiment-types";
@@ -13,6 +13,22 @@ const mobileAppConfig: IExperimentConfig = {
   showCameraButton: false
 };
 
+const ExpandoSchema: React.FC<{experiment: IExperiment}> = ({experiment}) => {
+  const [expanded, setExpanded] = useState(false);
+  const handleToggleExpanded = () => setExpanded(!expanded);
+
+  return (
+    <>
+      <div onClick={handleToggleExpanded} className="expando-title">{expanded ? "Hide" : "Show"} Experiment Schema JSON</div>
+      {expanded ?
+        <pre>
+          {JSON.stringify(experiment, null, 2)}
+        </pre>
+      : undefined}
+    </>
+  );
+};
+
 const experiment1 = ExperimentJSONs[0] as IExperiment;
 ReactDOM.render(
   <>
@@ -20,10 +36,7 @@ ReactDOM.render(
       experiment={experiment1}
       config={mobileAppConfig}
     />
-    <h4>Experiment Schema JSON</h4>
-    <pre>
-      {JSON.stringify(experiment1, null, 2)}
-    </pre>
+    <ExpandoSchema experiment={experiment1} />
   </>,
   document.getElementById("experiment-1")
 );
@@ -120,10 +133,7 @@ ReactDOM.render(
       experiment={experiment2}
       config={mobileAppConfig}
     />
-    <h4>Experiment Schema JSON</h4>
-    <pre>
-      {JSON.stringify(experiment2, null, 2)}
-    </pre>
+    <ExpandoSchema experiment={experiment2} />
   </>,
   document.getElementById("experiment-2")
 );
@@ -196,10 +206,9 @@ ReactDOM.render(
       experiment={experiment3}
       config={mobileAppConfig}
     />
-    <h4>Experiment Schema JSON</h4>
-    <pre>
-      {JSON.stringify(experiment3, null, 2)}
-    </pre>
+    <ExpandoSchema experiment={experiment3} />
   </>,
   document.getElementById("experiment-3")
 );
+
+


### PR DESCRIPTION
Adds the dropdown JSON Schema definition to tables.

This change is visible in example 3 in shared/index.html.  I also updated the shared/index.html file to make the schema json collapsible with the default being collapsed to reduce the amount of scrolling needed to test the various shared examples.