### PR TITLE
Add sensor picker ui [#171332391]

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ When testing in the browser the following url params are available:
 
 1. `?allowReset` - if present in query string the "Reset Local Data" button is shown under the experiment run list.  This param doesn't need a value.
 2. `?mockSensor` - if present in query string the mock sensor is automatically used in the measurement tab. This param doesn't need a value.
+3. `?showDevicePicker` - if present in query string the device picker is shown for the mock sensor. This param doesn't need a value.
 
 ## Development
 

--- a/src/mobile-app/components/sensor-strength.module.scss
+++ b/src/mobile-app/components/sensor-strength.module.scss
@@ -1,0 +1,8 @@
+.sensorStrength {
+  width: 25px;
+  height: 25px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  border-radius: 2;
+};

--- a/src/mobile-app/components/sensor-strength.test.ts
+++ b/src/mobile-app/components/sensor-strength.test.ts
@@ -1,0 +1,19 @@
+import { getStrength } from "./sensor-strength";
+
+describe("SensorStrength component", () => {
+  it("calculates the 0 to 100 strength from the -30 dBM to -60 dBM rssi value", () => {
+    // in range...
+    expect(getStrength(-30)).toBe(100);
+    expect(getStrength(-45)).toBe(75);
+    expect(getStrength(-60)).toBe(50);
+    expect(getStrength(-75)).toBe(25);
+    expect(getStrength(-90)).toBe(0);
+
+    // out of range
+    expect(getStrength(30)).toBe(100);
+    expect(getStrength(0)).toBe(100);
+    expect(getStrength(-29)).toBe(100);
+    expect(getStrength(-91)).toBe(0);
+    expect(getStrength(-991)).toBe(0);
+  })
+});

--- a/src/mobile-app/components/sensor-strength.test.ts
+++ b/src/mobile-app/components/sensor-strength.test.ts
@@ -15,5 +15,5 @@ describe("SensorStrength component", () => {
     expect(getStrength(-29)).toBe(100);
     expect(getStrength(-91)).toBe(0);
     expect(getStrength(-991)).toBe(0);
-  })
+  });
 });

--- a/src/mobile-app/components/sensor-strength.tsx
+++ b/src/mobile-app/components/sensor-strength.tsx
@@ -14,7 +14,7 @@ const rssiRange = maxRssi - minRssi;
 
 export const getStrength = (rssi: number) => {
   // -90 dBm -> -30 dBm : 0 -> 100
-  const clippedRssi = Math.min(maxRssi, Math.max(minRssi, rssi));
+  const clippedRssi = rssi > maxRssi ? maxRssi : (rssi < minRssi ? minRssi : rssi);
   const strength = 100 - (100 * ((maxRssi - clippedRssi) / rssiRange));
   return strength;
 }

--- a/src/mobile-app/components/sensor-strength.tsx
+++ b/src/mobile-app/components/sensor-strength.tsx
@@ -17,7 +17,7 @@ export const getStrength = (rssi: number) => {
   const clippedRssi = rssi > maxRssi ? maxRssi : (rssi < minRssi ? minRssi : rssi);
   const strength = 100 - (100 * ((maxRssi - clippedRssi) / rssiRange));
   return strength;
-}
+};
 
 export const SensorStrength: React.FC<IProps> = ({rssi}) => {
   const strength = getStrength(rssi);
@@ -38,5 +38,5 @@ export const SensorStrength: React.FC<IProps> = ({rssi}) => {
       <div style={barStyle(4)} />
     </div>
   );
-}
+};
 

--- a/src/mobile-app/components/sensor-strength.tsx
+++ b/src/mobile-app/components/sensor-strength.tsx
@@ -1,0 +1,42 @@
+// adapted from https://github.com/mbrookes/react-mobile-signal-strength
+
+import React from "react";
+
+import css from "./sensor-strength.module.scss";
+
+interface IProps {
+  rssi: number;
+}
+
+const minRssi = -90;
+const maxRssi = -30;
+const rssiRange = maxRssi - minRssi;
+
+export const getStrength = (rssi: number) => {
+  // -90 dBm -> -30 dBm : 0 -> 100
+  const clippedRssi = Math.min(maxRssi, Math.max(minRssi, rssi));
+  const strength = 100 - (100 * ((maxRssi - clippedRssi) / rssiRange));
+  return strength;
+}
+
+export const SensorStrength: React.FC<IProps> = ({rssi}) => {
+  const strength = getStrength(rssi);
+  const barStyle = (bar: number) => {
+    return {
+      borderRadius: 2,
+      width: '20%',
+      height: `${25 * bar}%`,
+      background: strength >= 25 * (bar - 1) + 10 ? 'green' : 'white',
+    };
+  };
+
+  return (
+    <div className={css.sensorStrength}>
+      <div style={barStyle(1)} />
+      <div style={barStyle(2)} />
+      <div style={barStyle(3)} />
+      <div style={barStyle(4)} />
+    </div>
+  );
+}
+

--- a/src/mobile-app/components/sensor.module.scss
+++ b/src/mobile-app/components/sensor.module.scss
@@ -1,3 +1,5 @@
+@import "../../shared/components/variables";
+
 .sensor {
   width: 100%;
 }
@@ -81,4 +83,54 @@
 .connectedValues {
 }
 .disconnectedValues {
+}
+
+.sensorSelector {
+  padding: 20px;
+  margin: 10px 0;
+  font-size: 15px;
+  background-color: #fadacb;
+
+  .sensorSelectorHeader {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+
+    .sensorSelectorHeaderTitle {
+      flex-grow: 1;
+      font-weight: bold;
+      font-size: 18px;
+    }
+    .sensorSelectorHeaderButton {
+      display: inline-block;
+      margin-right: 10px;
+      margin-bottom: 10px;
+      border: 1px solid $ccTealDark2;
+      background-color: #fff;
+      color: $ccTealDark2;
+      border-radius: 5px;
+      padding: 3px 8px 2px 10px;
+      text-transform: uppercase;
+      outline: none;
+    }
+    .sensorSelectorHeaderButton:hover {
+      background-color: rgba(11, 128, 155, 0.12);
+    }
+  }
+
+  .sensorSelectorItem {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+
+    margin: 15px 0;
+    font-size: 20px;
+
+    .sensorSelectorItemName {
+      flex-grow: 1;
+    }
+    .sensorSelectorItemRssi {
+      color: #777;
+    }
+  }
 }

--- a/src/mobile-app/components/sensor.tsx
+++ b/src/mobile-app/components/sensor.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import { SensorValue } from "./sensor-value";
 import { Sensor, IConnectDevice, SelectDeviceFn } from "../../sensors/sensor";
 import { useSensor } from "../hooks/use-sensor";
@@ -50,27 +50,33 @@ export const SensorComponent: React.FC<ISensorComponentProps> = ({sensor, hideMe
   const {connected, connecting, deviceName, values, error} = useSensor(sensor);
 
   const [devicesFound, setDevicesFound] = useState<IConnectDevice[]>([]);
-  const [selectDevice, setSelectDevice] = useState<SelectDeviceFn|undefined>();
-  const [cancelSelectDevice, setCancelSelectDevice] = useState<() => void|undefined>();
   const [showDeviceSelect, setShowDeviceSelect] = useState(false);
+  const selectDevice = useRef<SelectDeviceFn|undefined>();
+  const cancelSelectDevice = useRef<() => void|undefined>();
+
+  const clearSelectDevice = () => {
+    selectDevice.current = undefined;
+    cancelSelectDevice.current = undefined;
+    setShowDeviceSelect(false);
+  }
 
   const handleSelectDevice = (device: IConnectDevice) => {
-    if (selectDevice) {
-      setShowDeviceSelect(false);
-      selectDevice(device);
+    if (selectDevice.current) {
+      selectDevice.current(device);
+      clearSelectDevice();
     }
   };
 
   const handleCancelSelectDevice = () => {
-    cancelSelectDevice?.();
-    setShowDeviceSelect(false);
+    cancelSelectDevice.current?.();
+    clearSelectDevice();
   };
 
   const connect = () => sensor.connect({
     onDevicesFound: ({devices, select, cancel}) => {
       setDevicesFound(devices);
-      setSelectDevice(select);
-      setCancelSelectDevice(cancel);
+      selectDevice.current = select;
+      cancelSelectDevice.current = cancel;
       setShowDeviceSelect(true);
     }
   });

--- a/src/mobile-app/components/sensor.tsx
+++ b/src/mobile-app/components/sensor.tsx
@@ -91,7 +91,10 @@ export const SensorComponent: React.FC<ISensorComponentProps> = ({sensor, manual
       setShowDeviceSelect(true);
     }
   }).catch(() => sensor.disconnect());
-  const disconnect = () => sensor.disconnect();
+  const disconnect = () => {
+    sensor.disconnect();
+    clearSelectDevice();
+  };
 
   const renderIcon = (icon: "connected" | "disconnected" | "error") => (
     <div className={css.statusIcon}>

--- a/src/mobile-app/components/sensor.tsx
+++ b/src/mobile-app/components/sensor.tsx
@@ -52,7 +52,7 @@ export const SensorComponent: React.FC<ISensorComponentProps> = ({sensor, hideMe
   const [devicesFound, setDevicesFound] = useState<IConnectDevice[]>([]);
   const [showDeviceSelect, setShowDeviceSelect] = useState(false);
   const selectDevice = useRef<SelectDeviceFn|undefined>();
-  const cancelSelectDevice = useRef<() => void|undefined>();
+  const cancelSelectDevice = useRef<CancelDeviceFn|undefined>();
 
   const clearSelectDevice = () => {
     selectDevice.current = undefined;

--- a/src/mobile-app/components/sensor.tsx
+++ b/src/mobile-app/components/sensor.tsx
@@ -4,6 +4,7 @@ import { Sensor, IConnectDevice, SelectDeviceFn } from "../../sensors/sensor";
 import { useSensor } from "../hooks/use-sensor";
 import { MenuComponent, MenuItemComponent } from "../../shared/components/menu";
 import css from "./sensor.module.scss";
+import { inCordova } from "../../shared/utils/in-cordova";
 
 interface ISensorSelectorProps {
   devices: IConnectDevice[];
@@ -12,16 +13,21 @@ interface ISensorSelectorProps {
 }
 
 export const SensorSelectorComponent: React.FC<ISensorSelectorProps> = ({devices, selectDevice, cancel}) => {
+  const handleCancel = () => cancel();
   return (
     <div className={css.sensorSelector}>
+      <div className={css.sensorSelectorHeader}>
+        <div className={css.sensorSelectorHeaderTitle}>Choose a sensor...</div>
+        <div className={css.sensorSelectorHeaderButtons}>
+          <div className={css.sensorSelectorHeaderButton} onClick={handleCancel}>Cancel</div>
+        </div>
+      </div>
       {devices.map((device, index) => {
         const handleSelectDevice = () => selectDevice(device);
         return (
-          <div
-            key={index}
-            className={css.sensorSelectorItem}
-            onClick={handleSelectDevice}>
-              {device.name} ({device.adData.rssi})
+          <div key={index} className={css.sensorSelectorItem} onClick={handleSelectDevice}>
+            <div className={css.sensorSelectorItemName}>{device.name}</div>
+            <div className={css.sensorSelectorItemRssi}>{device.adData.rssi}</div>
           </div>
         );
       })}
@@ -58,7 +64,7 @@ export const SensorComponent: React.FC<ISensorComponentProps> = ({sensor, hideMe
     selectDevice.current = undefined;
     cancelSelectDevice.current = undefined;
     setShowDeviceSelect(false);
-  }
+  };
 
   const handleSelectDevice = (device: IConnectDevice) => {
     if (selectDevice.current) {
@@ -106,7 +112,7 @@ export const SensorComponent: React.FC<ISensorComponentProps> = ({sensor, hideMe
   const renderConnecting = () => (
     <div className={css.connectionLabel}>
       {renderIcon("connected")}
-      Connecting...
+      {inCordova ? "Searching..." : "Connecting..."}
     </div>
   );
 

--- a/src/mobile-app/components/sensor.tsx
+++ b/src/mobile-app/components/sensor.tsx
@@ -3,8 +3,10 @@ import { SensorValue } from "./sensor-value";
 import { Sensor, IConnectDevice, SelectDeviceFn } from "../../sensors/sensor";
 import { useSensor } from "../hooks/use-sensor";
 import { MenuComponent, MenuItemComponent } from "../../shared/components/menu";
-import css from "./sensor.module.scss";
 import { inCordova } from "../../shared/utils/in-cordova";
+import { SensorStrength } from "./sensor-strength";
+
+import css from "./sensor.module.scss";
 
 interface ISensorSelectorProps {
   devices: IConnectDevice[];
@@ -28,7 +30,9 @@ export const SensorSelectorComponent: React.FC<ISensorSelectorProps> = ({devices
         return (
           <div key={index} className={css.sensorSelectorItem} onClick={handleSelectDevice}>
             <div className={css.sensorSelectorItemName}>{device.name}</div>
-            <div className={css.sensorSelectorItemRssi}>{device.adData.rssi}</div>
+            <div className={css.sensorSelectorItemRssi}>
+              <SensorStrength rssi={device.adData.rssi} />
+            </div>
           </div>
         );
       })}
@@ -68,10 +72,8 @@ export const SensorComponent: React.FC<ISensorComponentProps> = ({sensor, hideMe
   };
 
   const handleSelectDevice = (device: IConnectDevice) => {
-    if (selectDevice.current) {
-      selectDevice.current(device);
-      clearSelectDevice();
-    }
+    selectDevice.current?.(device);
+    clearSelectDevice();
   };
 
   const handleCancelSelectDevice = () => {
@@ -86,7 +88,7 @@ export const SensorComponent: React.FC<ISensorComponentProps> = ({sensor, hideMe
       cancelSelectDevice.current = cancel;
       setShowDeviceSelect(true);
     }
-  });
+  }).catch(() => sensor.disconnect());
   const disconnect = () => sensor.disconnect();
 
   const renderIcon = (icon: "connected" | "disconnected" | "error") => (

--- a/src/mobile-app/components/sensor.tsx
+++ b/src/mobile-app/components/sensor.tsx
@@ -13,6 +13,7 @@ interface ISensorSelectorProps {
 }
 
 export const SensorSelectorComponent: React.FC<ISensorSelectorProps> = ({devices, selectDevice, cancel}) => {
+  const sortedDevices = devices.sort((a, b) => a.id.localeCompare(b.id));
   const handleCancel = () => cancel();
   return (
     <div className={css.sensorSelector}>
@@ -22,7 +23,7 @@ export const SensorSelectorComponent: React.FC<ISensorSelectorProps> = ({devices
           <div className={css.sensorSelectorHeaderButton} onClick={handleCancel}>Cancel</div>
         </div>
       </div>
-      {devices.map((device, index) => {
+      {sortedDevices.map((device, index) => {
         const handleSelectDevice = () => selectDevice(device);
         return (
           <div key={index} className={css.sensorSelectorItem} onClick={handleSelectDevice}>

--- a/src/sensors/bluetooth.d.ts
+++ b/src/sensors/bluetooth.d.ts
@@ -47,9 +47,13 @@ type RequestDeviceOptions = {
 	filters: BluetoothRequestDeviceFilter[];
 	optionalServices?: BluetoothServiceUUID[];
 	onDevicesFound?: OnDevicesFoundFn;
+	scanTime?: number;
+	deviceTimeout?: number;
 } | {
 	acceptAllDevices: boolean;
 	optionalServices?: BluetoothServiceUUID[];
+	scanTime?: number;
+	deviceTimeout?: number;
 };
 
 // tslint:disable-next-line:interface-name

--- a/src/sensors/bluetooth.d.ts
+++ b/src/sensors/bluetooth.d.ts
@@ -8,6 +8,28 @@
 //                 Rob Moran <https://github.com/thegecko>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+
+// this is an extension to the BLE interface to allow for search for devices
+interface IConnectDevice {
+	id: string;
+	name: string;
+	uuids: string;
+	adData: {
+		rssi: number;
+		txPower: number;
+		serviceData: any;
+		manufacturerData: any;
+	};
+}
+type SelectDeviceFn = (device: IConnectDevice) => void;
+type CancelDeviceFn = () => void;
+interface IOnDevicesFoundResult {
+	devices: IConnectDevice[];
+	select: SelectDeviceFn;
+	cancel: CancelDeviceFn;
+}
+type OnDevicesFoundFn = (results: IOnDevicesFoundResult) => void;
+
 type BluetoothServiceUUID = number | string;
 type BluetoothCharacteristicUUID = number | string;
 type BluetoothDescriptorUUID = number | string;
@@ -24,6 +46,7 @@ interface BluetoothRequestDeviceFilter {
 type RequestDeviceOptions = {
 	filters: BluetoothRequestDeviceFilter[];
 	optionalServices?: BluetoothServiceUUID[];
+	onDevicesFound?: OnDevicesFoundFn;
 } | {
 	acceptAllDevices: boolean;
 	optionalServices?: BluetoothServiceUUID[];

--- a/src/sensors/device-sensor.ts
+++ b/src/sensors/device-sensor.ts
@@ -39,11 +39,18 @@ export class DeviceSensor extends Sensor {
       if (!navigator.bluetooth) {
         return reject("Bluetooth not enabled in this environment");
       }
-      const options: RequestDeviceOptions = {
-        filters: this.getFilters(),
-        optionalServices: this.getOptionalServiceUUIDs(),
-        onDevicesFound: inCordova ? connectOptions.onDevicesFound : undefined
-      };
+      const options: RequestDeviceOptions =
+        inCordova ? {
+          filters: this.getFilters(),
+          optionalServices: this.getOptionalServiceUUIDs(),
+          // the following are extensions to the cordova-plugin-webbluetooth plugin to enable a sensor list
+          onDevicesFound: connectOptions.onDevicesFound, // callback when a new device is found
+          scanTime: -1, // scan forever
+          deviceTimeout: 5000 // drop devices from list after 5 seconds of not hearing from them
+        } : {
+          filters: this.getFilters(),
+          optionalServices: this.getOptionalServiceUUIDs()
+        };
       logInfo("Connecting using", options);
       navigator.bluetooth.requestDevice(options)
         .then(bluetoothDevice => {

--- a/src/sensors/device-sensor.ts
+++ b/src/sensors/device-sensor.ts
@@ -1,10 +1,11 @@
-import { Sensor, ISensorValues, ISensorOptions, ISensorCapabilities, ISetConnectedOptions, IPollOptions } from "./sensor";
+import { Sensor, ISensorValues, ISensorOptions, ISensorCapabilities, ISetConnectedOptions, IPollOptions, IConnectOptions } from "./sensor";
 
 import { Device } from "./devices/device";
 import { SensorTag2Device } from "./devices/sensor-tag-cc2650";
 import { SensorTagCC1350Device } from "./devices/sensor-tag-cc1350";
 import { MultiSensorDevice } from "./devices/multi-sensor";
 import { logInfo } from "../shared/utils/log";
+import { inCordova } from "../shared/utils/in-cordova";
 
 declare global {
   // tslint:disable-next-line:interface-name
@@ -28,7 +29,7 @@ export class DeviceSensor extends Sensor {
     ].filter(device => device.matchesCapabilities());
   }
 
-  public connect(): Promise<void> {
+  public connect(connectOptions: IConnectOptions): Promise<void> {
     // make sure we aren't already connected to something
     if (this.device) {
       this.setConnected({connected: false});
@@ -40,7 +41,8 @@ export class DeviceSensor extends Sensor {
       }
       const options: RequestDeviceOptions = {
         filters: this.getFilters(),
-        optionalServices: this.getOptionalServiceUUIDs()
+        optionalServices: this.getOptionalServiceUUIDs(),
+        onDevicesFound: inCordova ? connectOptions.onDevicesFound : undefined
       };
       logInfo("Connecting using", options);
       navigator.bluetooth.requestDevice(options)

--- a/src/sensors/mock-sensor.ts
+++ b/src/sensors/mock-sensor.ts
@@ -78,7 +78,7 @@ export class MockSensor extends Sensor {
             name: `Mocked Sensor ${i}`,
             uuids: `uuid${i}`,
             adData: {
-              rssi: -30 - Math.floor(Math.random() * 60),
+              rssi: -30 - Math.floor(Math.random() * 50),
               txPower: i,
               serviceData: {},
               manufacturerData: {}

--- a/src/sensors/mock-sensor.ts
+++ b/src/sensors/mock-sensor.ts
@@ -78,7 +78,7 @@ export class MockSensor extends Sensor {
             name: `Mocked Sensor ${i}`,
             uuids: `uuid${i}`,
             adData: {
-              rssi: Math.floor(Math.random() * 100),
+              rssi: -30 - Math.floor(Math.random() * 60),
               txPower: i,
               serviceData: {},
               manufacturerData: {}

--- a/src/sensors/sensor.ts
+++ b/src/sensors/sensor.ts
@@ -56,6 +56,24 @@ export interface IPollOptions {
   lastPoll?: boolean;
 }
 
+// NOTE: these two types need to be repeated in the bluetooth.d.ts declaration file
+export interface IConnectDevice {
+	id: string;
+	name: string;
+	uuids: string;
+	adData: {
+		rssi: number;
+		txPower: number;
+		serviceData: any;
+		manufacturerData: any;
+	};
+}
+export type SelectDeviceFn = (device: IConnectDevice) => void;
+
+export interface IConnectOptions {
+  onDevicesFound: OnDevicesFoundFn;
+}
+
 export class Sensor extends EventEmitter<SensorEvent> {
   protected _deviceName: string | undefined;
   private _connected: boolean;
@@ -90,7 +108,7 @@ export class Sensor extends EventEmitter<SensorEvent> {
     return this._deviceName || (this._connected ? "Unknown Device" : undefined);
   }
 
-  public connect(): Promise<void> {
+  public connect(options?: IConnectOptions): Promise<void> {
     return Promise.reject("connect() method not overridden!");
   }
 

--- a/src/shared/components/data-table-field.tsx
+++ b/src/shared/components/data-table-field.tsx
@@ -175,7 +175,8 @@ const getSensor = (sensorFields: string[]) => {
       sensorCache[key] = new MockSensor({
         capabilities,
         pollInterval: 500,
-        deviceName: "Mocked Sensor"
+        deviceName: "Mocked Sensor",
+        showDevicePicker: !!getURLParam("showDevicePicker") || false
       });
     } else {
       sensorCache[key] = new DeviceSensor({

--- a/src/shared/components/data-table-field.tsx
+++ b/src/shared/components/data-table-field.tsx
@@ -297,15 +297,6 @@ export const DataTableField: React.FC<FieldProps> = props => {
     }
   };
 
-  const setSensorMode = () => {
-    setManualEntryMode(false);
-  };
-
-  const setEditMode = () => {
-    sensor?.disconnect();
-    setManualEntryMode(true);
-  };
-
   const handleEditSaveButton = () => setManualEntryMode(!manualEntryMode);
   const handleImportButton = () => formContext.experimentConfig?.callbacks?.onImport();
 
@@ -438,30 +429,10 @@ export const DataTableField: React.FC<FieldProps> = props => {
 
   return (
     <div className={css.dataTable}>
-      <div className={css.menu}>
-        {
-          sensor &&
-          <MenuComponent>
-            {
-              manualEntryMode ?
-                <MenuItemComponent onClick={setSensorMode} icon="sensor">Sensor Mode</MenuItemComponent> :
-                <>
-                  {
-                    sensorOutput.connected ?
-                      <MenuItemComponent onClick={disconnectSensor}>Disconnect</MenuItemComponent> :
-                      <MenuItemComponent onClick={connectSensor}>Connect</MenuItemComponent>
-                  }
-                  <MenuItemComponent onClick={setEditMode} icon="create">Edit Mode</MenuItemComponent>
-                </>
-            }
-          </MenuComponent>
-        }
-      </div>
       <div className={css.topBar}>
         <div className={css.topBarLeft}>
-          {sensor && !manualEntryMode && <SensorComponent sensor={sensor} hideMenu={true}/>}
-          {manualEntryMode && <div className={css.editModeText}><Icon name="create" /> Edit values in the data table</div>}
-          {title && <div className={css.title}>{title}</div>}
+          {sensor ? <SensorComponent sensor={sensor} manualEntryMode={manualEntryMode} setManualEntryMode={setManualEntryMode} /> : undefined}
+          {title ? <div className={css.title}>{title}</div> : undefined}
         </div>
         <div className={css.topBarRight}>
           {!sensor && showImportButton ? <div className={css.button} onClick={handleImportButton}>Import</div> : undefined}

--- a/src/shared/index.html
+++ b/src/shared/index.html
@@ -16,7 +16,7 @@
     <div class="demo" id="experiment-2"></div>
     <h4>Data Table Example 2 (SUM function)</h4>
     <div class="demo" id="experiment-3"></div>
-    <h4>Data Table Example 3 (dropdown)</h4>
+    <h4>Data Table Example 3 (dropdown, no sensor)</h4>
     <div class="demo" id="experiment-4"></div>
   </body>
 </html>


### PR DESCRIPTION
Also fixes sensor disconnecting when entering edit mode and auto-reconnecting after connect -> disconnect -> connect.  Previously the sensor component was not rendered when entering edit mode which caused all its state to be lost.  Now it is always rendered and the menus option to enter/leave edit mode is pushed down into the sensor component.