### PR TITLE
172560741 adjust metadata

### DIFF
--- a/cypress/integration/branch/experiment.setup.spec.js
+++ b/cypress/integration/branch/experiment.setup.spec.js
@@ -2,103 +2,102 @@ import ExperimentSetup from "../../supports/elements/ExperimentSetup"
 
 context("Testing Experiment Selection View", () => {
 
-    //const branch = "master"
-    const url = "/mobile-app/?mockSensor"
+  //const branch = "master"
+  const url = "/mobile-app/?mockSensor"
 
-    let experimentSetup = new ExperimentSetup();
-    let testLabel1A = "WATERS Label Testing 1"
-    let testLabel1B = "WATERS Label Testing 2"
-    let testLabel2 = "WATERS Label Testing 3"
-    let testGroupMembers = "Ed, Edd, and Eddy"
-    let testDay = "Tue"
-    let studySite1 = "Study Site #1"
-    let studySite2 = "Study Site #2"
+  let experimentSetup = new ExperimentSetup();
+  let testLabel1A = "WATERS Label Testing 1"
+  let testLabel1B = "WATERS Label Testing 2"
+  let testLabel2 = "WATERS Label Testing 3"
+  let testGroupMembers = "Ed, Edd, and Eddy"
+  let testDay = "Tue"
+  let studySite1 = "Study Site #1"
+  let studySite2 = "Study Site #2"
+  let defaultSchoolyardInvestigation = "Schoolyard Investigation #1"
 
-    before(() => {
-        cy.visit(url);
-    });
+  before(() => {
+    cy.visit(url);
+  });
 
-    describe('Experiment Setup Defaults', () => {
+  describe('Experiment Setup Defaults', () => {
 
-        it("verifies presence of all default experiment options", () => {
-            experimentSetup.getNewExperimentOption('Schoolyard Investigation').should('be.visible')
-            experimentSetup.getNewExperimentOption('Stream Study').should('be.visible')
-        })
-
-        it("makes sure no experiments are saved to begin", () => {
-            experimentSetup.getSavedExperimentLabel().should('not.exist')
-        })
-
+    it("verifies presence of all default experiment options", () => {
+      experimentSetup.getNewExperimentOption('Schoolyard Investigation').should('be.visible')
+      experimentSetup.getNewExperimentOption('Stream Study').should('be.visible')
     })
 
-    describe("Tests School Yard Investigation", () => {
-
-        it("create and setup a schoolyard investigation", () => {
-            experimentSetup.openNewExperiment('Schoolyard Investigation')
-            experimentSetup.getBackButton().should('be.visible').click()
-            experimentSetup.getSavedExperimentLabel().should('exist').and('be.visible')
-            experimentSetup.getExperiment('Schoolyard Investigation', 1).should('be.visible')
-
-        })
-        it("edit experiment and verify changes", () => {
-            experimentSetup.getExperiment('Schoolyard Investigation', 1).click()
-            experimentSetup.getLabelTextBox().type(testLabel1A)
-            experimentSetup.getStudySiteDropDown().select(studySite1)
-            experimentSetup.getGroupMembersTextBox().type(testGroupMembers)
-            experimentSetup.getSubheader(studySite1)
-            experimentSetup.getBackButton().click()
-            experimentSetup.expandAllExperimentLabels()
-            experimentSetup.getExperimentLabel(studySite1).should('exist')
-        })
-        it('verifies label changes/removal from experiement', () => {
-            experimentSetup.getExperiment('Schoolyard Investigation', 1).click()
-            experimentSetup.getLabelTextBox().clear()
-            experimentSetup.getBackButton().click()
-            experimentSetup.getExperimentLabel(testLabel1A).should('not.exist')
-            experimentSetup.getExperiment('Schoolyard Investigation', 1).click()
-            experimentSetup.getLabelTextBox().type(testLabel1B)
-            experimentSetup.getBackButton().click()
-            experimentSetup.getExperimentLabel(testLabel1B).should('not.exist')
-        })
-        it('verifies study site changes from experiement', () => {
-          experimentSetup.getExperiment('Schoolyard Investigation', 1).click()
-          experimentSetup.getStudySiteDropDown().select(studySite1)
-          experimentSetup.getBackButton().click()
-          experimentSetup.getExperiment('Schoolyard Investigation', 1).click()
-          experimentSetup.getStudySiteDropDown().select(studySite2)
-          experimentSetup.getBackButton().click()
-          experimentSetup.expandAllExperimentLabels()
-          experimentSetup.getExperimentLabel(studySite2).should('be.visible')
-      })
-        it("delete Schooylard Investigation", () => {
-            experimentSetup.deleteExperiment()
-        })
-
+    it("makes sure no experiments are saved to begin", () => {
+      experimentSetup.getSavedExperimentLabel().should('not.exist')
     })
 
-    describe("Tests Stream Study Investigation", () => {
+  })
 
-        it("create and setup a stream study", () => {
-            experimentSetup.openNewExperiment('Stream Study')
-            experimentSetup.getBackButton().click()
-            experimentSetup.getSavedExperimentLabel().should('exist').and('be.visible')
-            experimentSetup.getExperiment('Stream Study', 1)
+  describe("Tests School Yard Investigation", () => {
 
-        })
-        it("edit experiment and verify changes", () => {
-            experimentSetup.getExperiment('Stream Study', 1).click()
-            experimentSetup.getLabelTextBox().type(testLabel2)
-            experimentSetup.getGroupMembersTextBox().type(testGroupMembers)
-            experimentSetup.getSubheader(testLabel2)
-            experimentSetup.getBackButton().click()
-            experimentSetup.expandAllExperimentLabels()
-            experimentSetup.getExperimentLabel(testLabel2).should('be.visible')
-        })
-
-        it("deletes Stream Study experiment", () => {
-            experimentSetup.deleteExperiment()
-        })
+    it("create and setup a schoolyard investigation", () => {
+      experimentSetup.openNewExperiment('Schoolyard Investigation')
+      experimentSetup.getBackButton().should('be.visible').click()
+      experimentSetup.getSavedExperimentLabel().should('exist').and('be.visible')
+      experimentSetup.getExperiment('Schoolyard Investigation', 1).should('be.visible')
 
     })
+    it('verifies name changes', () => {
+      experimentSetup.getExperiment('Schoolyard Investigation', 1).click()
+      experimentSetup.getExperimentName(defaultSchoolyardInvestigation).should('be.visible')
+      experimentSetup.getExperimentNameSpan().click()
+      experimentSetup.getNameInput().type(testLabel1A)
+      experimentSetup.getStudySiteDropDown().select(studySite1)
+      experimentSetup.getBackButton().click()
+      experimentSetup.getExperimentLabel(testLabel1A).should('exist')
+    })
+    it("edit experiment and verify changes", () => {
+      experimentSetup.getExperiment('Schoolyard Investigation', 1).click()
+      experimentSetup.getStudySiteDropDown().select(studySite1)
+      experimentSetup.getGroupMembersTextBox().type(testGroupMembers)
+      experimentSetup.getSubheader(studySite1)
+      experimentSetup.getBackButton().click()
+      experimentSetup.expandAllExperimentLabels()
+      experimentSetup.getExperimentLabel(studySite1).should('exist')
+    })
 
+    it('verifies study site changes from experiement', () => {
+      experimentSetup.getExperiment('Schoolyard Investigation', 1).click()
+      experimentSetup.getStudySiteDropDown().select(studySite1)
+      experimentSetup.getBackButton().click()
+      experimentSetup.getExperiment('Schoolyard Investigation', 1).click()
+      experimentSetup.getStudySiteDropDown().select(studySite2)
+      experimentSetup.getBackButton().click()
+      experimentSetup.expandAllExperimentLabels()
+      experimentSetup.getExperimentLabel(studySite2).should('be.visible')
+    })
+    it("delete Schooylard Investigation", () => {
+      experimentSetup.deleteExperiment()
+    })
+
+  })
+
+  describe("Tests Stream Study Investigation", () => {
+
+    it("create and setup a stream study", () => {
+      experimentSetup.openNewExperiment('Stream Study')
+      experimentSetup.getBackButton().click()
+      experimentSetup.getSavedExperimentLabel().should('exist').and('be.visible')
+      experimentSetup.getExperiment('Stream Study', 1)
+
+    })
+    it("edit experiment and verify changes", () => {
+      experimentSetup.getExperiment('Stream Study', 1).click()
+      experimentSetup.getExperimentNameSpan().click()
+      experimentSetup.getNameInput().type(testLabel2)
+      experimentSetup.getGroupMembersTextBox().type(testGroupMembers)
+      experimentSetup.getSubheader(testLabel2)
+      experimentSetup.getBackButton().click()
+      experimentSetup.expandAllExperimentLabels()
+      experimentSetup.getExperimentLabel(testLabel2).should('be.visible')
+    })
+
+    it("deletes Stream Study experiment", () => {
+      experimentSetup.deleteExperiment()
+    })
+  })
 })

--- a/cypress/supports/elements/ExperimentSetup.js
+++ b/cypress/supports/elements/ExperimentSetup.js
@@ -45,6 +45,18 @@ class ExperimentSetup {
         return cy.get('.experiment-wrapper-module-headerBackIcon-vortex')
     }
 
+    getNameInput() {
+      return cy.get('.experiment-wrapper-module-editing-vortex input').focus()
+    }
+
+    getExperimentNameSpan() {
+      return cy.get('.experiment-wrapper-module-nameDisplay-vortex')
+    }
+
+    getExperimentName(name) {
+      return cy.get('.experiment-wrapper-module-nameDisplay-vortex').contains(name)
+    }
+
     getStudySiteDropDown() {
         return cy.get('.form-control#root_studySite')
     }

--- a/src/data/experiments.json
+++ b/src/data/experiments.json
@@ -15,7 +15,6 @@
           "icon": "assignment",
           "formFields": [
             "studySite",
-            "label",
             "groupMembers"
           ],
           "components": [
@@ -58,10 +57,6 @@
               "Study Site #1",
               "Study Site #2"
             ]
-          },
-          "label": {
-            "title": "Label",
-            "type": "string"
           },
           "groupMembers": {
             "title": "Group Members",
@@ -126,10 +121,6 @@
         "studySite": {
           "ui:icon": "assignment",
           "ui:placeholder": "Study Site"
-        },
-        "label": {
-          "ui:icon": "label",
-          "ui:placeholder": "My Experiment 1"
         },
         "groupMembers": {
           "ui:icon": "group",

--- a/src/mobile-app/components/experiment-wrapper.module.scss
+++ b/src/mobile-app/components/experiment-wrapper.module.scss
@@ -8,6 +8,9 @@
   flex-wrap: nowrap;
   align-items: center;
   background-color: $ccTealDark2;
+  .nameDisplay{
+    display: flex;
+  }
   .editing{
     display: flex;
     input{

--- a/src/mobile-app/components/experiment-wrapper.tsx
+++ b/src/mobile-app/components/experiment-wrapper.tsx
@@ -77,7 +77,7 @@ export const ExperimentWrapper: React.FC<IProps> = ({ experiment, experimentIdx,
             </div>
           }
           {!editing &&
-            <div><span onClick={handleRename}>{name}</span></div>
+            <div><span className={css.nameDisplay} onClick={handleRename}>{name}</span></div>
           }
           <div>{title}</div>
         </div>


### PR DESCRIPTION
Remove the Label field from the form by editing` src/data/experiments.json`, update tests accordingly.
The change diff for the Cypress tests is larger because of formatting fixes. The main addition was `cypress/integration/branch/experiment.setup.spec.js` lines 44-51 for testing the changes to the name of the experiment, and removing calls to `getLabelTextBox()`