### PR TITLE
UI Cleanup [#172609679]

### DIFF
--- a/src/data/experiments.json
+++ b/src/data/experiments.json
@@ -14,6 +14,7 @@
           "title": "Label",
           "icon": "assignment",
           "formFields": [
+            "customName",
             "studySite",
             "groupMembers"
           ],
@@ -118,6 +119,10 @@
         }
       },
       "formUiSchema": {
+        "customName":{
+          "ui:icon": "label",
+          "ui:placeholder": "My Investigation"
+        },
         "studySite": {
           "ui:icon": "assignment",
           "ui:placeholder": "Study Site"
@@ -184,15 +189,15 @@
       "initials": "SS"
     },
     "schema": {
-      "titleField": "label",
+      "titleField": "studySite",
       "customNameField": "customName",
       "sections": [
         {
           "title": "Label",
           "icon": "assignment",
           "formFields": [
+            "customName",
             "studySite",
-            "label",
             "groupMembers"
           ],
           "components": [
@@ -217,8 +222,7 @@
       "dataSchema": {
         "type": "object",
         "required": [
-          "studySite",
-          "label"
+          "studySite"
         ],
         "properties": {
           "customName": {
@@ -236,10 +240,6 @@
               "Study Site #1",
               "Study Site #2"
             ]
-          },
-          "label": {
-            "title": "Label",
-            "type": "string"
           },
           "groupMembers": {
             "title": "Group Members",
@@ -317,13 +317,13 @@
         }
       },
       "formUiSchema": {
+        "customName":{
+          "ui:icon": "label",
+          "ui:placeholder": "My Investigation"
+        },
         "studySite": {
           "ui:icon": "assignment",
           "ui:placeholder": "Study Site"
-        },
-        "label": {
-          "ui:icon": "label",
-          "ui:placeholder": "My Experiment 1"
         },
         "groupMembers": {
           "ui:icon": "group",

--- a/src/mobile-app/components/experiment-wrapper.module.scss
+++ b/src/mobile-app/components/experiment-wrapper.module.scss
@@ -52,6 +52,11 @@
   svg {
     fill: #fff;
   }
+  div div{
+    svg{
+      fill: $ccTealDark2;
+    }
+  }
 }
 
 .workspace {

--- a/src/mobile-app/components/experiment-wrapper.tsx
+++ b/src/mobile-app/components/experiment-wrapper.tsx
@@ -84,9 +84,9 @@ export const ExperimentWrapper: React.FC<IProps> = ({ experiment, experimentIdx,
         </div>
         <div className={css.headerMenu}>
           <MenuComponent>
-            <MenuItemComponent onClick={handleSave}>Save</MenuItemComponent>
-            <MenuItemComponent onClick={onUpload}>Upload</MenuItemComponent>
-            <MenuItemComponent onClick={handleRename}>Rename</MenuItemComponent>
+            <MenuItemComponent icon={"label"} onClick={handleSave}>Save</MenuItemComponent>
+            <MenuItemComponent icon={"upload"} onClick={onUpload}>Upload</MenuItemComponent>
+            <MenuItemComponent icon={"create"} onClick={handleRename}>Rename</MenuItemComponent>
           </MenuComponent>
         </div>
       </div>

--- a/src/mobile-app/components/sensor.tsx
+++ b/src/mobile-app/components/sensor.tsx
@@ -111,7 +111,7 @@ export const SensorComponent: React.FC<ISensorComponentProps> = ({sensor, manual
   );
 
   const renderDisconnected = () => (
-    <div className={css.connectionLabel}>
+    <div className={css.connectionLabel} onClick={connect}>
       {renderIcon("disconnected")}
       No Sensor Connected
     </div>

--- a/src/mobile-app/components/sensor.tsx
+++ b/src/mobile-app/components/sensor.tsx
@@ -141,7 +141,7 @@ export const SensorComponent: React.FC<ISensorComponentProps> = ({sensor, manual
         {manualEntryMode && canSwitchModes
           ? <MenuItemComponent onClick={setSensorMode} icon="sensor">Sensor Mode</MenuItemComponent>
           : <>
-              {connected ? <MenuItemComponent onClick={disconnect}>Disconnect</MenuItemComponent> : <MenuItemComponent onClick={connect}>Connect</MenuItemComponent>}
+              {connected ? <MenuItemComponent onClick={disconnect}>Disconnect</MenuItemComponent> : <MenuItemComponent icon="settings_input_antenna" onClick={connect}>Connect</MenuItemComponent>}
               {canSwitchModes ? <MenuItemComponent onClick={setEditMode} icon="create">Edit Mode</MenuItemComponent> : undefined}
             </>}
       </MenuComponent>

--- a/src/shared/components/menu.tsx
+++ b/src/shared/components/menu.tsx
@@ -6,7 +6,9 @@ interface IMenuItemProps {
   onClick: () => void;
   icon?: string;
 }
-
+interface IMenuProps {
+  icon?: string;
+}
 export const MenuItemComponent: React.FC<IMenuItemProps> = ({onClick, icon, children}) => {
   return (
     <div className={css.menuItem} onClick={onClick}>
@@ -16,7 +18,7 @@ export const MenuItemComponent: React.FC<IMenuItemProps> = ({onClick, icon, chil
   );
 };
 
-export const MenuComponent: React.FC = (props) => {
+export const MenuComponent: React.FC<IMenuProps> = (props) => {
   // need to use both a state variable and a ref variable to hold showing status
   // the state variable change triggers the re-render and the ref variable
   // is available in the global handleClick() handler (the state variable would
@@ -57,10 +59,11 @@ export const MenuComponent: React.FC = (props) => {
       </div>
     );
   };
-
+  const menuIcon = props.icon ? props.icon : "menu";
+  console.log(menuIcon);
   return (
     <div className={css.menuIcon} onClick={handleMenuIcon}>
-      <Icon name="menu"/>
+      <Icon name={menuIcon}/>
       {showMenu ? renderMenu() : undefined}
     </div>
   );

--- a/src/shared/components/menu.tsx
+++ b/src/shared/components/menu.tsx
@@ -60,7 +60,6 @@ export const MenuComponent: React.FC<IMenuProps> = (props) => {
     );
   };
   const menuIcon = props.icon ? props.icon : "menu";
-  console.log(menuIcon);
   return (
     <div className={css.menuIcon} onClick={handleMenuIcon}>
       <Icon name={menuIcon}/>

--- a/src/shared/components/photo-or-note-field.module.scss
+++ b/src/shared/components/photo-or-note-field.module.scss
@@ -67,6 +67,7 @@
       position: relative;
       display: flex;
       flex-wrap: nowrap;
+      background: #fff;
 
       .thumbnail {
         width: 80px;

--- a/src/shared/components/photo-or-note-field.module.scss
+++ b/src/shared/components/photo-or-note-field.module.scss
@@ -101,15 +101,19 @@
   .photo {
     position: relative;
     overflow: hidden;
-
     .photoMenu {
       position: absolute;
       top: 5px;
-
       svg {
         fill: #fff;
       }
+      div div{
+        svg{
+          fill: $ccTealDark2;
+        }
+      }
     }
+
   }
 
   .photoNote {

--- a/src/shared/components/photo-or-note-field.tsx
+++ b/src/shared/components/photo-or-note-field.tsx
@@ -117,8 +117,8 @@ export const Photo: React.FC<IPhotoProps> = ({photo, deletePhoto, saveAll, width
     <>
       <div className={css.photo}>
         <div className={css.photoMenu} style={{right: menuRight}}>
-          <MenuComponent>
-            <MenuItemComponent onClick={handleDeletePhoto}>Delete Photo</MenuItemComponent>
+          <MenuComponent icon={"delete"}>
+            <MenuItemComponent icon={"delete"} onClick={handleDeletePhoto}>Delete Photo</MenuItemComponent>
           </MenuComponent>
         </div>
         <Image src={localPhotoUrl || remotePhotoUrl} width={imageWidth} height={imageHeight} marginLeft={imageMarginLeft} />
@@ -145,8 +145,8 @@ export const Note: React.FC<{note: IPhotoOrNote, deleteNote: (note: IPhotoOrNote
   return (
     <div className={css.note}>
       <div className={css.noteMenu}>
-        <MenuComponent>
-          <MenuItemComponent onClick={handleDeleteNote}>Delete Note</MenuItemComponent>
+        <MenuComponent icon={"delete"}>
+          <MenuItemComponent icon={"delete"} onClick={handleDeleteNote}>Delete Note</MenuItemComponent>
         </MenuComponent>
       </div>
       <div className={css.noteText}>{note.note}</div>

--- a/src/shared/components/photo-or-note-field.tsx
+++ b/src/shared/components/photo-or-note-field.tsx
@@ -261,6 +261,7 @@ export const PhotoOrNoteField: React.FC<FieldProps> = props => {
     };
     updateFormData([newPhoto, ...formData]);
     setSelectedPhoto(newPhoto);
+    setTimeout(() => setSelectedPhoto(undefined), 2000);
   };
 
   const renderNoteSubTab = () => {
@@ -277,47 +278,6 @@ export const PhotoOrNoteField: React.FC<FieldProps> = props => {
       const selectedPhotoKey = selectedPhoto ? formData.indexOf(selectedPhoto) : -1;
       const photoHeight = windowInfo.height - photoSubTabTop - 100; // 100 is thumbnail height with padding
       const photoWidth = windowInfo.width;
-
-      // manually handle horizontal scrolling
-      // this sets the thumbnailListLeft state variable which ranges from 0 to -maxLeft
-      const handleThumbnailScrollStart = (eStart: React.MouseEvent<HTMLDivElement>|React.TouchEvent<HTMLDivElement>) => {
-        const isTouch = eStart.type === "touchstart";
-
-        const mouseStartEvent = eStart as React.MouseEvent<HTMLDivElement>;
-        const touchStartEvent = eStart as React.TouchEvent<HTMLDivElement>;
-
-        const startLeft = thumbnailListLeft;
-        const startX = touchStartEvent.touches?.[0].clientX || mouseStartEvent.clientX;
-        const maxLeft = Math.min(0, windowInfo.width - thumbnailListWidth);
-
-        let moved = false;
-        const onMove = (eMove: MouseEvent|TouchEvent) => {
-          eMove.stopPropagation();
-          eMove.preventDefault();
-          const mouseMoveEvent = eMove as MouseEvent;
-          const touchMoveEvent = eMove as TouchEvent;
-          const dx = (touchMoveEvent.touches?.[0].clientX || mouseMoveEvent.clientX) - startX;
-          const newLeft = Math.max(maxLeft, Math.min(startLeft + dx, 0));
-          setThumbnailListLeft(newLeft);
-          moved = true;
-        };
-
-        const onEnd = (eUp: MouseEvent|TouchEvent) => {
-          if (moved) {
-            // prevent selecting a thumbnail
-            eUp.stopPropagation();
-            eUp.preventDefault();
-          }
-          window.removeEventListener(isTouch ? "touchmove" : "mousemove", onMove);
-          window.removeEventListener(isTouch ? "touchend" : "mouseup", onEnd);
-        };
-
-        // the passive flag disables Chrome console warnings about cancelling events
-        // see https://developers.google.com/web/updates/2017/01/scrolling-intervention
-        window.addEventListener(isTouch ? "touchmove" : "mousemove", onMove, {passive: false});
-        window.addEventListener(isTouch ? "touchend" : "mouseup", onEnd, {passive: false});
-      };
-
       return (
         <>
           <Photo
@@ -328,30 +288,12 @@ export const PhotoOrNoteField: React.FC<FieldProps> = props => {
             width={photoWidth}
             height={photoHeight}
           />
-          <div className={css.thumbnails}>
-            <div
-              className={css.thumbnailList}
-              style={{left: thumbnailListLeft}}
-              ref={el => setThumbnailListWidth(el?.getBoundingClientRect().width || 0)}
-              onMouseDown={handleThumbnailScrollStart}
-              onTouchStart={handleThumbnailScrollStart}
-            >
-              {showCameraButton && photos().length > 0 ?
-                <div className={css.addPhoto} onClick={handleAddPhoto}>
-                  <Icon name="camera" />
-                </div> : undefined}
-              {photos().map((photo) => {
-                const selected = photo === selectedPhoto;
-                return <Thumbnail key={photo.timestamp} photo={photo} selected={selected} selectPhoto={setSelectedPhoto} />;
-              })}
-            </div>
-          </div>
         </>
       );
     }
 
     if (showCameraButton) {
-      const cameraHeight = windowInfo.height - photoSubTabTop - 30; // 15 is the margin
+      const cameraHeight = windowInfo.height - photoSubTabTop - 100; // 15 is the margin
       const cameraWidth = windowInfo.width;
 
       return <Camera onPhoto={handleCameraPhoto} width={cameraWidth} height={cameraHeight} />;
@@ -360,10 +302,73 @@ export const PhotoOrNoteField: React.FC<FieldProps> = props => {
     return undefined;
   };
 
+  const renderThumbnails = () => {
+    // manually handle horizontal scrolling
+    // this sets the thumbnailListLeft state variable which ranges from 0 to -maxLeft
+    const handleThumbnailScrollStart = (eStart: React.MouseEvent<HTMLDivElement>|React.TouchEvent<HTMLDivElement>) => {
+      const isTouch = eStart.type === "touchstart";
+
+      const mouseStartEvent = eStart as React.MouseEvent<HTMLDivElement>;
+      const touchStartEvent = eStart as React.TouchEvent<HTMLDivElement>;
+
+      const startLeft = thumbnailListLeft;
+      const startX = touchStartEvent.touches?.[0].clientX || mouseStartEvent.clientX;
+      const maxLeft = Math.min(0, windowInfo.width - thumbnailListWidth);
+
+      let moved = false;
+      const onMove = (eMove: MouseEvent|TouchEvent) => {
+        eMove.stopPropagation();
+        eMove.preventDefault();
+        const mouseMoveEvent = eMove as MouseEvent;
+        const touchMoveEvent = eMove as TouchEvent;
+        const dx = (touchMoveEvent.touches?.[0].clientX || mouseMoveEvent.clientX) - startX;
+        const newLeft = Math.max(maxLeft, Math.min(startLeft + dx, 0));
+        setThumbnailListLeft(newLeft);
+        moved = true;
+      };
+
+      const onEnd = (eUp: MouseEvent|TouchEvent) => {
+        if (moved) {
+          // prevent selecting a thumbnail
+          eUp.stopPropagation();
+          eUp.preventDefault();
+        }
+        window.removeEventListener(isTouch ? "touchmove" : "mousemove", onMove);
+        window.removeEventListener(isTouch ? "touchend" : "mouseup", onEnd);
+      };
+
+      // the passive flag disables Chrome console warnings about cancelling events
+      // see https://developers.google.com/web/updates/2017/01/scrolling-intervention
+      window.addEventListener(isTouch ? "touchmove" : "mousemove", onMove, {passive: false});
+      window.addEventListener(isTouch ? "touchend" : "mouseup", onEnd, {passive: false});
+    };
+    return (
+      <div className={css.thumbnails}>
+        <div
+          className={css.thumbnailList}
+          style={{ left: thumbnailListLeft }}
+          ref={el => setThumbnailListWidth(el?.getBoundingClientRect().width || 0)}
+          onMouseDown={handleThumbnailScrollStart}
+          onTouchStart={handleThumbnailScrollStart}
+        >
+          {showCameraButton && photos().length > 0 ?
+            <div className={css.addPhoto} onClick={handleAddPhoto}>
+              <Icon name="camera" />
+            </div> : undefined}
+          {photos().map((photo) => {
+            const selected = photo === selectedPhoto;
+            return <Thumbnail key={photo.timestamp} photo={photo} selected={selected} selectPhoto={setSelectedPhoto} />;
+          })}
+        </div>
+      </div>
+    );
+  };
+
   const renderPhotoSubTab = () => {
     return (
       <div className={css.photoSubTab} ref={(el) => setPhotoSubTabTop(el?.getBoundingClientRect().top || 0)}>
         {renderCameraOrPhoto()}
+        {renderThumbnails()}
       </div>
     );
   };

--- a/src/shared/components/photo-or-note-field.tsx
+++ b/src/shared/components/photo-or-note-field.tsx
@@ -165,7 +165,7 @@ export const PhotoOrNoteField: React.FC<FieldProps> = props => {
 
   const addNoteRef = useRef<HTMLTextAreaElement|null>(null);
   const [formData, setFormData] = useState<IPhotoOrNoteData>(props.formData || []);
-  const [subTab, setSubTab] = useState<"note" | "photo">("note");
+  const [subTab, setSubTab] = useState<"note" | "photo">("photo");
   const [lastSaved, setLastSaved] = useState<Date | undefined>(undefined);
 
   const photos = () => formData.filter(item => item.isPhoto);
@@ -373,8 +373,8 @@ export const PhotoOrNoteField: React.FC<FieldProps> = props => {
   return (
     <div className={css.photoOrNote}>
       <div className={css.subTabs}>
-        <div className={subTabClassName("note")} onClick={handleSelectNoteSubTab}><Icon name="comment" /></div>
         <div className={subTabClassName("photo")} onClick={handleSelectPhotoSubTab}><Icon name="photo" /></div>
+        <div className={subTabClassName("note")} onClick={handleSelectNoteSubTab}><Icon name="comment" /></div>
       </div>
       {subTab === "note" ? renderNoteSubTab() : renderPhotoSubTab() }
     </div>


### PR DESCRIPTION
Update the UI in response to feedback to include the following:

- Menu icons adjusted to show the Delete icon on the photos page to delete a photo. I left the functionality as-is, so the menu will show you a "delete" option when you click it (a useful "are you sure")
- Menu icons added for Save, Upload, and Rename on Experiment header
- Added rename for Experiment via a form field instead of in the header
- Changed camera functionality to show the picture you just took for 2s then return to taking more pictures. I left the thumbnails on screen to give the user the option of viewing their photos.
- Notes and Photos order of tabs flipped
- Sensor icon, when disconnected, can be tapped to connect, instead of using the menu
- Added missing icon for Connect menu option