### PR TITLE
Fixing the sticky Cordova plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ You may need to do this a few times to set both `Debug` and `Release` signing mo
 If you make any changes to the `cordova-app` code you run `npm run build:cordova-app` in the project root,
 then run `npm run cordova -- prepare ios` and run again in Xcode to see the change.
 
+#### Cordova: Updating plugins and packages
+
+Cordova can be quite sticky with plugins and packages, and updates to which plugins you are using may not show up. To clean up the
+Cordova installation and start fresh (preserving project configuration settings for XCode etc.) run the following script:
+
+1. `cd src/cordova-wrapper`
+2. `./clean.sh`
+
+This will backup configuration, then remove all the Cordova target platforms, re-prepare each of them, and restore configuration.
 
 ### Notes
 

--- a/src/cordova-wrapper/clean.sh
+++ b/src/cordova-wrapper/clean.sh
@@ -1,0 +1,32 @@
+IOS='./platforms/ios'
+IOS_backupfile='./ios_backup.tgz'
+
+IOS_project='Vortex.xcodeproj'
+IOS_workspace='Vortex.xcworkspace'
+IOS_plist='Vortex-Info.plist'
+
+spacer='\n---------------------\n'
+
+if [ -d "$IOS" ]; then
+  echo "$IOS is a current build target. Backing up xcode configuration..."
+  tar czf $IOS_backupfile "$IOS/$IOS_project" "$IOS/$IOS_workspace" "$IOS/Vortex/$IOS_plist"
+else
+  echo "$IOS does not exist - likely has not been setup for deployment"
+fi
+echo $spacer
+echo "Removing previous build targets..."
+rm -rf node_modules
+rm -rf plugins
+rm -rf platforms
+echo $spacer
+echo "Preparing Corova platforms..."
+cordova prepare browser
+cordova prepare android
+cordova prepare ios
+echo $spacer
+if [ -f "$IOS_backupfile" ]; then
+  echo "Restoring xcode configuration..."
+  tar xzf $IOS_backupfile
+  rm $IOS_backupfile
+fi
+echo "Done!"

--- a/src/cordova-wrapper/package.json
+++ b/src/cordova-wrapper/package.json
@@ -3,7 +3,11 @@
     "cordova": "cordova",
     "run:browser": "cordova run browser",
     "run:android": "cordova run android --emulator",
-    "run:android:device": "cordova run android --device"
+    "run:android:device": "cordova run android --device",
+    "clean:cordova:full": "rm -rf node_modules; rm -rf plugins; rm -rf platforms",
+    "clean:cordova:android": "rm -rf node_modules; rm -rf plugins; rm -rf platforms/android",
+    "clean:cordova": "cordova clean",
+    "prepare:all": "cordova prepare browser; cordova prepare android; cordova prepare ios"
   },
   "devDependencies": {
     "cordova": "^9.0.0",
@@ -38,6 +42,6 @@
     "cordova-plugin-compat": "^1.2.0",
     "cordova-plugin-dialogs": "^2.0.2",
     "cordova-plugin-ionic-webview": "^4.1.3",
-    "cordova-plugin-webbluetooth": "git+https://github.com/concord-consortium/cordova-plugin-webbluetooth.git"
+    "cordova-plugin-webbluetooth": "git+https://github.com/concord-consortium/cordova-plugin-webbluetooth.git#32bc2f274d9de4ff7dc920cb5b36c25f01503145"
   }
 }

--- a/src/cordova-wrapper/package.json
+++ b/src/cordova-wrapper/package.json
@@ -3,11 +3,7 @@
     "cordova": "cordova",
     "run:browser": "cordova run browser",
     "run:android": "cordova run android --emulator",
-    "run:android:device": "cordova run android --device",
-    "clean:cordova:full": "rm -rf node_modules; rm -rf plugins; rm -rf platforms",
-    "clean:cordova:android": "rm -rf node_modules; rm -rf plugins; rm -rf platforms/android",
-    "clean:cordova": "cordova clean",
-    "prepare:all": "cordova prepare browser; cordova prepare android; cordova prepare ios"
+    "run:android:device": "cordova run android --device"
   },
   "devDependencies": {
     "cordova": "^9.0.0",
@@ -42,6 +38,6 @@
     "cordova-plugin-compat": "^1.2.0",
     "cordova-plugin-dialogs": "^2.0.2",
     "cordova-plugin-ionic-webview": "^4.1.3",
-    "cordova-plugin-webbluetooth": "git+https://github.com/concord-consortium/cordova-plugin-webbluetooth.git#32bc2f274d9de4ff7dc920cb5b36c25f01503145"
+    "cordova-plugin-webbluetooth": "git+https://github.com/concord-consortium/cordova-plugin-webbluetooth.git"
   }
 }


### PR DESCRIPTION
I made a simple script that gives a reliable way to clean out the old code from Cordova installations. It made it much easier to test out new versions of the bluetooth plugin, and it preserves my xcode settings, so no more copy-paste by hand. 