### PR TITLE
Export dataset that can be consumed by the graph interactive

### DIFF
--- a/src/lara-app/components/app.tsx
+++ b/src/lara-app/components/app.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useRef, useCallback } from "react";
+import React from "react";
 import { useState } from "react";
 import "firebase/firestore";
 import "firebase/auth";
-import ResizeObserver from "resize-observer-polyfill";
 
 // TODO: Discuss how / when to use the S3 authoring selection component.
 // import { LaraAuthoringComponent } from "../../authoring-app/components/lara-authoring";
@@ -19,7 +18,9 @@ interface IProps {
 
 export const AppComponent:React.FC<IProps> = ({defaultSectionIndex}) => {
   const [error, setError] = useState<any>();
-  const {connectedToLara, initInteractiveData, experiment, previewMode, firebaseJWT, runKey, phone, setHeight} = useInteractiveApi({setError});
+  const {
+    connectedToLara, initInteractiveData, experiment, previewMode, firebaseJWT, runKey, phone, setHeight, setDataset
+  } = useInteractiveApi({setError});
 
   const renderMessage = (message: string) => <div className={css.message}>{message}</div>;
 
@@ -56,6 +57,7 @@ export const AppComponent:React.FC<IProps> = ({defaultSectionIndex}) => {
         experiment={experiment}
         runKey={runKey}
         firebaseJWT={firebaseJWT}
+        setDataset={setDataset}
         setError={setError}
         defaultSectionIndex={defaultSectionIndex}
         reportMode={initInteractiveData.mode === "report"}

--- a/src/lara-app/components/runtime.tsx
+++ b/src/lara-app/components/runtime.tsx
@@ -45,7 +45,7 @@ export const generateDataset = (data: IExperimentData, experiment: IExperiment):
     return null;
   }
   const propTitles = propNames.map(n => dataProps[n].title);
-  const rows = data.experimentData.map(row => propNames.map(name => row[name]));
+  const rows = data.experimentData.map((row: Record<string, number | string>) => propNames.map(name => row[name]));
   if (!rows || rows.length === 0) {
     return null;
   }

--- a/src/lara-app/components/runtime.tsx
+++ b/src/lara-app/components/runtime.tsx
@@ -3,7 +3,7 @@ import * as firebase from "firebase/app";
 import "firebase/firestore";
 import { Experiment } from "../../shared/components/experiment";
 import { IExperiment, IExperimentData, IExperimentConfig } from "../../shared/experiment-types";
-import { IFirebaseJWT } from "../hooks/interactive-api";
+import { IDataset, IFirebaseJWT } from "../hooks/interactive-api";
 import { IRun } from "../../mobile-app/hooks/use-runs";
 import { createCodeForExperimentRun, getSaveExperimentRunUrl } from "../../shared/api";
 import { CODE_LENGTH } from "../../mobile-app/components/uploader";
@@ -28,6 +28,7 @@ export type IQRCodeContent = IQRCodeContentV1 | IQRCodeContentV11;
 
 interface IProps {
   experiment: IExperiment;
+  setDataset: (dataset: IDataset | null) => void;
   runKey?: string;
   firebaseJWT?: IFirebaseJWT;
   setError: (error: any) => void;
@@ -37,7 +38,31 @@ interface IProps {
   setHeight: (height: number) => void;
 }
 
-export const RuntimeComponent = ({experiment, runKey, firebaseJWT, setError, defaultSectionIndex, reportMode, previewMode, setHeight} : IProps) => {
+export const generateDataset = (data: IExperimentData, experiment: IExperiment): IDataset | null => {
+  const dataProps = experiment.schema.dataSchema.properties.experimentData?.items?.properties || {};
+  const propNames = Object.keys(dataProps);
+  if (propNames.length === 0) {
+    return null;
+  }
+  const propTitles = propNames.map(n => dataProps[n].title);
+  const rows = data.experimentData.map(row => propNames.map(name => row[name]));
+  if (!rows || rows.length === 0) {
+    return null;
+  }
+  return {
+    type: "dataset",
+    version: "1",
+    properties: propTitles,
+    // Always use first property as X axis. It might be necessary to customize that in the future, but it doesn't
+    // seem useful now.
+    xAxisProp: propTitles[0],
+    rows
+  };
+};
+
+export const RuntimeComponent = ({
+  experiment, runKey, firebaseJWT, setError, defaultSectionIndex, reportMode, previewMode, setHeight, setDataset
+} : IProps) => {
   const [experimentData, setExperimentData] = useState<IExperimentData|undefined>();
   const [queriedFirestore, setQueriedFirestore] = useState(false);
   const [qrCode, setQRCode] = useState("");
@@ -144,8 +169,10 @@ export const RuntimeComponent = ({experiment, runKey, firebaseJWT, setError, def
   const toggleDisplayQr = () => setDisplayQrAndMaybeRegenerateQR(!displayQr);
 
   const handleSaveData = (data: IExperimentData) => {
+    // Always set/save dataset, even in preview mode. It lets graph interactive get access to it and render itself.
+    setDataset(generateDataset(data, experiment));
     // no runKey or firebaseJWT in preview mode - need to check these explicitly to make typescript happy
-    if (!runKey || !firebaseJWT) {
+    if (reportOrPreviewMode || !runKey || !firebaseJWT) {
       return;
     }
 
@@ -199,7 +226,7 @@ export const RuntimeComponent = ({experiment, runKey, firebaseJWT, setError, def
             data={experimentData}
             config={config}
             defaultSectionIndex={defaultSectionIndex}
-            onDataChange={reportOrPreviewMode ? undefined : handleSaveData}
+            onDataChange={handleSaveData}
           />
         </div>
         {(displayQr && experimentData === undefined) &&

--- a/src/lara-app/hooks/interactive-api.ts
+++ b/src/lara-app/hooks/interactive-api.ts
@@ -45,7 +45,7 @@ export interface IDataset {
   version: "1";
   properties: string[];
   xAxisProp: string;
-  rows: (number | string)[][]
+  rows: (number | string)[][];
 }
 
 interface IInteractiveStateJSON {


### PR DESCRIPTION
[#175739194]

Data is saved in the linked interactive state. That way, graph interactive can start observing Votex's interactive state, grab this dataset and plot it. 

If you have some suggestions re `IDataset` naming, props, or data structure, I'd be happy to hear that. I used an array of arrays for data to keep it more efficient in case we'd like to plot large datasets (on each update dataset needs to be saved in Firestore - not the best for very large datasets, but small and medium are fine).