### PR TITLE
Send initial, empty dataset to parent (LARA / AP)

### DIFF
--- a/src/lara-app/components/runtime.tsx
+++ b/src/lara-app/components/runtime.tsx
@@ -9,14 +9,12 @@ import { createCodeForExperimentRun, getSaveExperimentRunUrl } from "../../share
 import { CODE_LENGTH } from "../../mobile-app/components/uploader";
 import { getURLParam } from "../../shared/utils/get-url-param";
 import ResizeObserver from "resize-observer-polyfill";
-import { handleSpecialValue, IDataTableData, IDataTableRow  } from "../../shared/utils/handle-special-value";
 import { IDataset } from "@concord-consortium/lara-interactive-api";
 const QRCode = require("qrcode-svg");
-
-const UPDATE_QR_INTERVAL = 1000 * 60 * 60;  // 60 minutes
-
+import { generateDataset } from "../utils/generate-dataset";
 import css from "./runtime.module.scss";
 
+const UPDATE_QR_INTERVAL = 1000 * 60 * 60;  // 60 minutes
 
 export interface IQRCodeContentV1 {
   version: "1.0.0";
@@ -39,34 +37,6 @@ interface IProps {
   previewMode?: boolean;
   setHeight: (height: number) => void;
 }
-
-export const generateDataset = (data: IExperimentData, experiment: IExperiment): IDataset | null => {
-  const dataProps = experiment.schema.dataSchema.properties.experimentData?.items?.properties || {};
-  const propNames = Object.keys(dataProps);
-  if (propNames.length === 0) {
-    return null;
-  }
-  const propTitles = propNames.map(n => dataProps[n].title);
-  const experimentData = data.experimentData as IDataTableData;
-  const rows = experimentData.map((row: IDataTableRow) =>
-    propNames.map(name =>
-      // Handle values like <AVG>, <STDDEV>, <SUM>, etc.
-      handleSpecialValue(row[name], name, experimentData) || null
-    )
-  );
-  if (!rows || rows.length === 0) {
-    return null;
-  }
-  return {
-    type: "dataset",
-    version: 1,
-    properties: propTitles,
-    // Always use first property as X axis. It might be necessary to customize that in the future, but it doesn't
-    // seem useful now.
-    xAxisProp: propTitles[0],
-    rows
-  };
-};
 
 export const RuntimeComponent = ({
   experiment, runKey, firebaseJWT, setError, defaultSectionIndex, reportMode, previewMode, setHeight, setDataset

--- a/src/lara-app/utils/generate-dataset.test.tsx
+++ b/src/lara-app/utils/generate-dataset.test.tsx
@@ -1,4 +1,4 @@
-import { generateDataset } from "./runtime";
+import { generateDataset } from "./generate-dataset";
 import { IExperiment } from "../../shared/experiment-types";
 
 describe("generateDataset helper", () => {

--- a/src/lara-app/utils/generate-dataset.ts
+++ b/src/lara-app/utils/generate-dataset.ts
@@ -1,0 +1,28 @@
+import { IExperiment, IExperimentData } from "../../shared/experiment-types";
+import { IDataset } from "@concord-consortium/lara-interactive-api";
+import { handleSpecialValue, IDataTableData, IDataTableRow } from "../../shared/utils/handle-special-value";
+
+export const generateDataset = (data: IExperimentData, experiment: IExperiment): IDataset | null => {
+  const dataProps = experiment.schema.dataSchema.properties.experimentData?.items?.properties || {};
+  const propNames = Object.keys(dataProps);
+  if (propNames.length === 0) {
+    return null;
+  }
+  const propTitles = propNames.map(n => dataProps[n].title);
+  const experimentData = data.experimentData as IDataTableData;
+  const rows = experimentData.map((row: IDataTableRow) =>
+    propNames.map(name =>
+      // Handle values like <AVG>, <STDDEV>, <SUM>, etc.
+      handleSpecialValue(row[name], name, experimentData) || null
+    )
+  );
+  return {
+    type: "dataset",
+    version: 1,
+    properties: propTitles,
+    // Always use first property as X axis. It might be necessary to customize that in the future, but it doesn't
+    // seem useful now.
+    xAxisProp: propTitles[0],
+    rows
+  };
+};


### PR DESCRIPTION
[#175787319]

The main change here is that the dataset is generated immediately after the experiment description is available. This dataset won't have any user data obviously, but it still includes some information (property names) that can be useful for graph interactive to generate empty graphs.