### PR TITLE
Use preview mode when getFirebaseJwt isn't supported by the host

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1983,9 +1983,9 @@
       }
     },
     "@concord-consortium/lara-interactive-api": {
-      "version": "0.7.0-pre.3",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-0.7.0-pre.3.tgz",
-      "integrity": "sha512-oXWfrcaOY6weaXWWr22EvnJsOe0JiIbvhv+9x4A8HYcU4lP7pwP+2p2VV8obI2WfcDkubdSnCZYD43aw6SN9Ew==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-0.7.0.tgz",
+      "integrity": "sha512-I8lT9aRPy1ygU5EchSRHI5LjRlSdGiXqlIJrvCQw0V+7cBG7G70ZcZqGJLQaftzi/4iQ9+t9NlNCRl0lwDrgTA==",
       "requires": {
         "iframe-phone": "^1.3.1"
       },

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "webpack-dev-server": "^3.10.1"
   },
   "dependencies": {
-    "@concord-consortium/lara-interactive-api": "^0.7.0-pre.3",
+    "@concord-consortium/lara-interactive-api": "^0.7.0",
     "@concord-consortium/lara-plugin-api": "^3.1.2",
     "@concord-consortium/token-service": "^1.2.0",
     "ace-builds": "^1.4.8",

--- a/src/lara-app/components/runtime.tsx
+++ b/src/lara-app/components/runtime.tsx
@@ -3,7 +3,6 @@ import * as firebase from "firebase/app";
 import "firebase/firestore";
 import { Experiment } from "../../shared/components/experiment";
 import { IExperiment, IExperimentData, IExperimentConfig } from "../../shared/experiment-types";
-import { IFirebaseJWT } from "../hooks/interactive-api";
 import { IRun } from "../../mobile-app/hooks/use-runs";
 import { createCodeForExperimentRun, getSaveExperimentRunUrl } from "../../shared/api";
 import { CODE_LENGTH } from "../../mobile-app/components/uploader";
@@ -13,6 +12,7 @@ import { IDataset } from "@concord-consortium/lara-interactive-api";
 const QRCode = require("qrcode-svg");
 import { generateDataset } from "../utils/generate-dataset";
 import css from "./runtime.module.scss";
+import { IJwtClaims } from "@concord-consortium/lara-plugin-api";
 
 const UPDATE_QR_INTERVAL = 1000 * 60 * 60;  // 60 minutes
 
@@ -30,7 +30,7 @@ interface IProps {
   experiment: IExperiment;
   setDataset: (dataset: IDataset | null) => void;
   runKey?: string;
-  firebaseJWT?: IFirebaseJWT;
+  firebaseJWT?: IJwtClaims;
   setError: (error: any) => void;
   defaultSectionIndex?: number;
   reportMode?: boolean;
@@ -52,7 +52,7 @@ export const RuntimeComponent = ({
   const reportOrPreviewMode = reportMode || previewMode;
   const containerRef = useRef<HTMLDivElement|null>(null);
 
-  const generateQRCode = (options: {runKey: string, firebaseJWT: IFirebaseJWT}) => {
+  const generateQRCode = (options: {runKey: string, firebaseJWT: IJwtClaims}) => {
     return createCodeForExperimentRun(options.runKey, options.firebaseJWT.claims).then(code => {
       const content = JSON.stringify({
         version: "1.1.0",

--- a/src/lara-app/hooks/interactive-api.test.ts
+++ b/src/lara-app/hooks/interactive-api.test.ts
@@ -1,0 +1,23 @@
+import { isGetFirebaseJwtSupported } from "./interactive-api";
+import { IInitInteractive } from "@concord-consortium/lara-interactive-api";
+
+describe("isGetFirebaseJwtSupported", () => {
+  it("returns true when init message hostFeatures provides supported version", () => {
+    expect(isGetFirebaseJwtSupported(
+      { mode: "runtime", hostFeatures: { getFirebaseJwt: { version: "1.0.0" } } } as unknown as IInitInteractive
+    )).toEqual(true);
+    expect(isGetFirebaseJwtSupported(
+      { mode: "runtime", hostFeatures: { getFirebaseJwt: { version: "1.0.1" } } } as unknown as IInitInteractive
+    )).toEqual(true);
+    expect(isGetFirebaseJwtSupported(
+      { mode: "runtime", hostFeatures: { getFirebaseJwt: { version: "1.1.1" } } } as unknown as IInitInteractive
+    )).toEqual(true);
+
+    expect(isGetFirebaseJwtSupported(
+      { mode: "runtime", hostFeatures: { getFirebaseJwt: { version: "2.0.0" } } } as unknown as IInitInteractive
+    )).toEqual(false);
+    expect(isGetFirebaseJwtSupported(
+      { mode: "runtime", hostFeatures: {} } as unknown as IInitInteractive
+    )).toEqual(false);
+  });
+})

--- a/src/lara-app/hooks/interactive-api.test.ts
+++ b/src/lara-app/hooks/interactive-api.test.ts
@@ -20,4 +20,4 @@ describe("isGetFirebaseJwtSupported", () => {
       { mode: "runtime", hostFeatures: {} } as unknown as IInitInteractive
     )).toEqual(false);
   });
-})
+});


### PR DESCRIPTION
[#175787385]

.getFirebaseJwt is part of the .hostFatures now. Init code checks if it's present and the right version, and if not, it just enabled preview mode. That fixes the "waiting to connect to Firestore..." message in LARA authoring preview.

Depends on:
https://github.com/concord-consortium/activity-player/pull/87