### PR TITLE
Make sure that existing dataset in LARA/AP is not overwritten by an empty one

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vortex",
-  "version": "0.0.1",
+  "version": "1.3.1",
   "description": "Vortex: the data capture system where all your data disappears into a black hole",
   "main": "index.js",
   "jest": {


### PR DESCRIPTION
[#177741885]

Vortex was overwriting the existing dataset stored in LARA or AP with an empty one on the initial load. It was causing graphs not to show any data on the page load until the user made any change and the correct dataset was sent to LARA/AP again.

