### PR TITLE
fix: Authored state lookup in authoring mode [PT-187809702]

### DIFF
--- a/src/lara-app/components/authoring.tsx
+++ b/src/lara-app/components/authoring.tsx
@@ -38,7 +38,6 @@ export const AuthoringComponent = (props : IProps) => {
           })}
         </>
       </select>
-      <div className={css.note}>Once you select an experiment please click the "Save authored state" button above to save your choice.</div>
     </div>
   );
 };

--- a/src/lara-app/hooks/interactive-api.ts
+++ b/src/lara-app/hooks/interactive-api.ts
@@ -70,9 +70,19 @@ export const useInteractiveApi = (options: {setError: (error: any) => void}) => 
         setConnectedToLara(true);
 
         let _experiment;
-        if (data.authoredState && (data.authoredState.version === "1.0")) {
-          experimentId.current = data.authoredState.experimentId;
-          _experiment = findExperiment(data.authoredState.experimentId);
+        let authoredState = data.authoredState;
+        // In authoring mode the authored state comes in as a string
+        // which causes the authoring preview to show an error
+        if (typeof authoredState === "string") {
+          try {
+            authoredState = JSON.parse(authoredState);
+          } catch (e) {
+            // noop
+          }
+        }
+        if (authoredState?.version === "1.0") {
+          experimentId.current = authoredState.experimentId;
+          _experiment = findExperiment(authoredState.experimentId);
           setExperiment(_experiment);
         }
 


### PR DESCRIPTION
This fixes a couple of issues found when testing out authoring:

In authoring mode the authoredState comes in as a string which was causing the authoring preview to show an error that the experiment was not selected.

There was still a reference to the "Save Authored State" button, which I believe came from the S3 authoring version.