### PR TITLE
fix: Disable disable controls for now [PT-187852896]

### DIFF
--- a/src/shared/components/data-table-field.tsx
+++ b/src/shared/components/data-table-field.tsx
@@ -370,7 +370,9 @@ export const DataTableField: React.FC<FieldProps> = props => {
         return;
       }
 
-      setInputDisabled?.(true);
+      // TODO: RE-ENABLE
+      // DISABLED FOR NOW AS THIS BREAKS DATA SAVING
+      // setInputDisabled?.(true);
 
       const timeSeriesMetadata = getTimeSeriesMetadata(timeSeriesCapabilities);
 
@@ -409,7 +411,9 @@ export const DataTableField: React.FC<FieldProps> = props => {
       stopTimeSeriesFnRef.current = undefined;
       timeSeriesRecordingRowRef.current = undefined;
       saveData(finalData);
-      setInputDisabled?.(false);
+      // TODO: RE-ENABLE
+      // DISABLED FOR NOW AS THIS BREAKS DATA SAVING
+      // setInputDisabled?.(false);
     }
   };
 


### PR DESCRIPTION
Disabling the controls breaks data saving as currently implemented.  This may be due to the entire page re-rendering as it is a top level page prop.

This will need to be fixed but it is being disabled for now to enable testing of the rest of the app.