### PR TITLE
feat: Add ability to select time series label for csv [PT-187816321]

### DIFF
--- a/src/data/experiments.json
+++ b/src/data/experiments.json
@@ -44,7 +44,8 @@
                 "label": {
                   "title": "Label",
                   "type": "string",
-                  "placeholder": "Label #$N"
+                  "placeholder": "Label #$N",
+                  "isTimeSeriesLabel": true
                 }
               }
             }

--- a/src/lara-app/utils/download-csv.test.ts
+++ b/src/lara-app/utils/download-csv.test.ts
@@ -59,7 +59,11 @@ const timeSeriesExperiment: IExperiment = {
                 title: "Results"
               },
               label: {
-                title: "Label"
+                title: "Label",
+                isTimeSeriesLabel: true
+              },
+              extraData: {
+                title: "Extra Data"
               }
             }
           }
@@ -79,8 +83,8 @@ const timeSeriesExperiment: IExperiment = {
 const timeSeriesData: IExperimentData = {
   timestamp: 987654321,
   experimentData: [
-    {[TimeSeriesDataKey]: [1, 2], [TimeSeriesMetadataKey]: { measurementPeriod: 1000}, label: "Label #1"},
-    {[TimeSeriesDataKey]: [3, 4], [TimeSeriesMetadataKey]: { measurementPeriod: 2000}, label: "Label #2"}
+    {[TimeSeriesDataKey]: [1, 2], [TimeSeriesMetadataKey]: { measurementPeriod: 1000}, label: "First Label", extraData: "one"},
+    {[TimeSeriesDataKey]: [3, 4], [TimeSeriesMetadataKey]: { measurementPeriod: 2000}, label: "Second Label", extraData: "two"}
   ]
 };
 
@@ -126,24 +130,24 @@ describe("download csv functions", () => {
       expect(getRows(timeSeriesExperiment, timeSeriesData)).toStrictEqual([
         {
           "Time": "0",
-          "Row 1 Results": "1",
-          "Row 2 Results": "3",
-          "Row 1 Label": "Label #1",
-          "Row 2 Label": "Label #2",
+          "First Label": "1",
+          "Second Label": "3",
+          "Row 1 Extra Data": "one",
+          "Row 2 Extra Data": "two",
         },
         {
           "Time": "1",
-          "Row 1 Results": "2",
-          "Row 2 Results": "",
-          "Row 1 Label": "Label #1",
-          "Row 2 Label": "Label #2",
+          "First Label": "2",
+          "Second Label": "",
+          "Row 1 Extra Data": "one",
+          "Row 2 Extra Data": "two",
         },
         {
           "Time": "2",
-          "Row 1 Results": "",
-          "Row 2 Results": "4",
-          "Row 1 Label": "Label #1",
-          "Row 2 Label": "Label #2",
+          "First Label": "",
+          "Second Label": "4",
+          "Row 1 Extra Data": "one",
+          "Row 2 Extra Data": "two",
         },
       ]);
     });

--- a/src/lara-app/utils/download-csv.ts
+++ b/src/lara-app/utils/download-csv.ts
@@ -40,7 +40,8 @@ export const getRows = (experiment: IExperiment, data: IExperimentData) => {
   const isTimeSeries = (experiment.schema.formUiSchema?.experimentData?.["ui:dataTableOptions"]?.sensorFields || []).indexOf(TimeSeriesDataKey) !== -1;
 
   if (isTimeSeries) {
-    const nonTimeSeriesTitles = Object.keys(titleMap).filter(key => key !== TimeSeriesDataKey);
+    const timeSeriesLabelKey = Object.keys(properties).find(key => properties[key].isTimeSeriesLabel);
+    const nonTimeSeriesTitles = Object.keys(titleMap).filter(key => (key !== TimeSeriesDataKey) && (key !== timeSeriesLabelKey));
     const timeKeys = new Set<string>();
     const timeSeriesRows: TimeSeriesRow[] = [];
 
@@ -72,7 +73,8 @@ export const getRows = (experiment: IExperiment, data: IExperimentData) => {
     sortedTimeKeys.forEach(timeKey => {
       const row: Record<string, any> = {Time: timeKey};
       timeSeriesRows.forEach(({timeValues}, rowIndex) => {
-        row[`Row ${rowIndex + 1} ${timeSeriesKey}`] = timeValues[timeKey] ?? "";
+        const rowKey = ((timeSeriesLabelKey && rawRows[rowIndex][timeSeriesLabelKey]) as string|undefined) || `Row ${rowIndex + 1} ${timeSeriesKey}`;
+        row[rowKey] = timeValues[timeKey] ?? "";
       });
       timeSeriesRows.forEach(({otherValues}, rowIndex) => {
         nonTimeSeriesTitles.forEach(key => {

--- a/src/shared/components/data-table-field.tsx
+++ b/src/shared/components/data-table-field.tsx
@@ -48,6 +48,7 @@ interface IDataTableArrayField {
   title?: string;
   readOnly?: boolean;
   placeholder?: string;
+  isTimeSeriesLabel?: boolean;
 }
 
 interface IDataTableDataSchema {


### PR DESCRIPTION
This allows the experiment author to select a experiment table attribute to use as the timeseries data label in the csv output.