### PR TITLE
feat: Save experiment data in interactive state [PT-187809685]

### DIFF
--- a/src/lara-app/components/app.tsx
+++ b/src/lara-app/components/app.tsx
@@ -18,7 +18,7 @@ interface IProps {
 export const AppComponent:React.FC<IProps> = () => {
   const [error, setError] = useState<any>();
   const {
-    connectedToLara, initMessage, experiment, previewMode, firebaseJWT, runKey, setAuthoredState, setHeight, setDataset, log
+    connectedToLara, initMessage, experiment, previewMode, firebaseJWT, runKey, setAuthoredState, setHeight, log, saveExperimentData, interactiveState
   } = useInteractiveApi({setError});
 
   const renderMessage = (message: string) => <div className={css.message}>{message}</div>;
@@ -62,7 +62,8 @@ export const AppComponent:React.FC<IProps> = () => {
         experiment={experiment}
         runKey={runKey}
         firebaseJWT={firebaseJWT}
-        setDataset={setDataset}
+        saveExperimentData={saveExperimentData}
+        interactiveState={interactiveState}
         setError={setError}
         defaultSectionIndex={defaultSectionIndex}
         reportMode={initMessage.mode === "report"}

--- a/src/shared/components/experiment.tsx
+++ b/src/shared/components/experiment.tsx
@@ -15,9 +15,10 @@ interface IProps {
   inputDisabled?: boolean;
   setInputDisabled?: React.Dispatch<React.SetStateAction<boolean>>;
   log?: (action: string, data?: object | undefined) => void;
+  reportMode?: boolean;
 }
 
-export const Experiment: React.FC<IProps> = ({ experiment, data, onDataChange, config, defaultSectionIndex, inputDisabled, setInputDisabled, log }) => {
+export const Experiment: React.FC<IProps> = ({ experiment, data, onDataChange, config, defaultSectionIndex, inputDisabled, setInputDisabled, log, reportMode }) => {
   const { schema } = experiment;
   const { sections } = schema;
   const [section, setSection] = useState<ISection>(sections[defaultSectionIndex || 0]);
@@ -65,7 +66,7 @@ export const Experiment: React.FC<IProps> = ({ experiment, data, onDataChange, c
           experiment={experiment}
           experimentConfig={config}
           formData={currentData}
-          inputDisabled={inputDisabled}
+          inputDisabled={inputDisabled || reportMode}
           setInputDisabled={setInputDisabled}
           onDataChange={onExperimentDataChange}
           log={log}

--- a/src/shared/components/photo-or-note-field.tsx
+++ b/src/shared/components/photo-or-note-field.tsx
@@ -85,12 +85,13 @@ interface IPhotoProps {
   saveAll: () => void;
   width: number;
   height: number;
+  inputDisabled?: boolean;
 }
 
-export const Photo: React.FC<IPhotoProps> = ({photo, deletePhoto, saveAll, width, height}) => {
+export const Photo: React.FC<IPhotoProps> = ({photo, deletePhoto, saveAll, width, height, inputDisabled}) => {
   const {localPhotoUrl, remotePhotoUrl} = photo;
   const addCaptionRef = useRef<HTMLInputElement|null>(null);
-  const handleDeletePhoto = () => deletePhoto(photo);
+  const handleDeletePhoto = () => !inputDisabled && deletePhoto(photo);
   const handleAddCaptionKeyUp = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (addCaptionRef.current) {
       photo.note = addCaptionRef.current.value.trim();
@@ -139,16 +140,16 @@ export const Thumbnail: React.FC<{photo: IPhotoOrNote, selected: boolean, select
   );
 };
 
-export const Note: React.FC<{note: IPhotoOrNote, deleteNote: (note: IPhotoOrNote) => void}> = ({note, deleteNote}) => {
+export const Note: React.FC<{note: IPhotoOrNote, deleteNote: (note: IPhotoOrNote) => void, inputDisabled?: boolean}> = ({note, deleteNote, inputDisabled}) => {
   const localTime = (new Date(note.timestamp)).toLocaleString();
-  const handleDeleteNote = () => deleteNote(note);
+  const handleDeleteNote = () => !inputDisabled && deleteNote(note);
   return (
     <div className={css.note}>
-      <div className={css.noteMenu}>
+      {!inputDisabled && <div className={css.noteMenu}>
         <MenuComponent icon={"delete"}>
           <MenuItemComponent icon={"delete"} onClick={handleDeleteNote}>Delete Note</MenuItemComponent>
         </MenuComponent>
-      </div>
+      </div>}
       <div className={css.noteText}>{note.note}</div>
       <div className={css.noteTimestamp}>{localTime}</div>
     </div>
@@ -184,6 +185,7 @@ export const PhotoOrNoteField: React.FC<FieldProps> = props => {
   const showCameraButton = !!formContext.experimentConfig?.showCameraButton;
   const minCameraWidth = formContext.experimentConfig?.minCameraWidth || 0;
   const minCameraHeight = formContext.experimentConfig?.minCameraHeight || 0;
+  const inputDisabled = formContext.inputDisabled;
 
   const updateFormData = (newFormData: IPhotoOrNote[]) => {
     setFormData(newFormData);
@@ -222,7 +224,7 @@ export const PhotoOrNoteField: React.FC<FieldProps> = props => {
   const handleSelectNoteSubTab = () => setSubTab("note");
   const handleSelectPhotoSubTab = () => setSubTab("photo");
   const handleAddNoteKeyUp = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (addNoteRef.current) {
+    if (!inputDisabled && addNoteRef.current) {
       const note = addNoteRef.current.value.trim();
       if ((note.length > 0) && (e.keyCode === 13)) {
         e.preventDefault();
@@ -238,6 +240,9 @@ export const PhotoOrNoteField: React.FC<FieldProps> = props => {
     }
   };
   const handleDeletePhotoOrNote = (item: IPhotoOrNote) => {
+    if (inputDisabled) {
+      return;
+    }
     const newFormData = formData.slice();
     const index = formData.indexOf(item);
     newFormData.splice(index, 1);
@@ -269,8 +274,8 @@ export const PhotoOrNoteField: React.FC<FieldProps> = props => {
   const renderNoteSubTab = () => {
     return (
       <div className={css.noteSubTab}>
-        <textarea className={css.addNote} ref={addNoteRef} placeholder="Add a note" onKeyUp={handleAddNoteKeyUp} />
-        {notes().map((note, index) => <Note key={index} note={note} deleteNote={handleDeletePhotoOrNote} />)}
+        {!inputDisabled && <textarea className={css.addNote} ref={addNoteRef} placeholder="Add a note" onKeyUp={handleAddNoteKeyUp} />}
+        {notes().map((note, index) => <Note key={index} note={note} deleteNote={handleDeletePhotoOrNote} inputDisabled={inputDisabled} />)}
       </div>
     );
   };
@@ -290,6 +295,7 @@ export const PhotoOrNoteField: React.FC<FieldProps> = props => {
             saveAll={handleSaveAll}
             width={width}
             height={height}
+            inputDisabled={inputDisabled}
           />
         </>
       );

--- a/src/shared/components/section.tsx
+++ b/src/shared/components/section.tsx
@@ -21,6 +21,7 @@ interface IProps {
   inputDisabled?: boolean;
   setInputDisabled?: React.Dispatch<React.SetStateAction<boolean>>;
   log?: (action: string, data?: object | undefined) => void;
+  reportMode?: boolean;
 }
 
 const SectionComponent: {[name in SectionComponentName]: SectionComponent} = {


### PR DESCRIPTION
This allows for the experiment to be viewed in the class dashboard.  The data is primarily stored in Firebase but the class dashboard does not grant Firebase JWT tokens.

This also updates the lara runtime component to disable inputs when viewing in report mode.