### PR TITLE
fix: Stop sensor before restarting recording [PT-187900630]

### DIFF
--- a/src/sensors/devices/gdx-sensor.ts
+++ b/src/sensors/devices/gdx-sensor.ts
@@ -96,13 +96,17 @@ export class GDXSensorDevice extends Device {
         time += delta;
       }
     };
-    this.gdxDevice.sensors.forEach((sensor: any) => {
-      if (sensor.number === selectableSensorId) {
-        sensor.on("value-changed", handleChange);
-      }
-    });
 
-    this.gdxDevice.start(measurementPeriod);
+    // need to use internal _stopMeasurements function as stop() doesn't return the promise
+    this.gdxDevice._stopMeasurements().then(() => {
+      this.gdxDevice.sensors.forEach((sensor: any) => {
+        if (sensor.number === selectableSensorId) {
+          sensor.on("value-changed", handleChange);
+        }
+      });
+
+      this.gdxDevice.start(measurementPeriod);
+    });
 
     return () => {
       this.gdxDevice?.sensors.forEach((sensor: any) => {

--- a/src/shared/components/data-table-field.tsx
+++ b/src/shared/components/data-table-field.tsx
@@ -547,8 +547,8 @@ export const DataTableField: React.FC<FieldProps> = props => {
         const values: number[] = value || [];
         const metadata = (row[TimeSeriesMetadataKey] ?? {measurementPeriod: 0});
         const {measurementPeriod} = metadata;
-        const time = values.length * (measurementPeriod / 1000);
-        const graphTitle = values.length > 0 ? `${Math.round(time)} sec` : "";
+        const time = Math.max(0, values.length - 1) * (measurementPeriod / 1000);
+        const graphTitle = `${Math.round(time)} sec`;
 
         contents =
           <div className={css.sparkgraphContainer}>


### PR DESCRIPTION
The GDX sensor was not being stopped before restarting recording which caused erroneous values to be displayed when the sample rate was lowered as they would immediately be recorded.

This also updates the spark graph label to start at time 0.  This was evident at the 0.1 sampler rate as the label was immediately showing 10 seconds at the start.