### PR TITLE
187792765 automation for time series data display

### DIFF
--- a/cypress/integration/branch/experiment.setup.spec.js
+++ b/cypress/integration/branch/experiment.setup.spec.js
@@ -1,4 +1,5 @@
 import ExperimentSetup from "../../supports/elements/ExperimentSetup"
+import SensorData from "../../supports/elements/SensorData"
 
 context("Testing Experiment Selection View", () => {
 
@@ -14,6 +15,8 @@ context("Testing Experiment Selection View", () => {
   let studySite1 = "Study Site #1"
   let studySite2 = "Study Site #2"
   let defaultSchoolyardInvestigation = "Schoolyard Investigation #1"
+
+  let sensorData = new SensorData();
 
   before(() => {
     cy.visit(url);
@@ -99,5 +102,37 @@ context("Testing Experiment Selection View", () => {
     it("deletes Stream Study experiment", () => {
       experimentSetup.deleteExperiment()
     })
+  })
+
+  describe("Tests Data Trial", () => {
+
+    it.only("create and setup a data trial", () => {
+      experimentSetup.openNewExperiment('Data Trial')
+      //cy.wait(500)
+      
+      sensorData.getExperimentOptionsMenu() // gets the click in the helper function
+      sensorData.selectMenuOption('Connect')
+
+      // Select and verify the "Mocked Sensor: Temperature" option
+      sensorData.selectSensor('Temperature')
+      cy.get('div.sensor-module-connectionLabel-vortex select')
+          .should('have.value', '1');
+
+    })
+    // this is pasted code from above
+    // it("edit experiment and verify changes", () => {
+    //   experimentSetup.getExperiment('Stream Study', 1).click()
+    //   experimentSetup.getExperimentNameSpan().click()
+    //   experimentSetup.getNameInput().type(testLabel2)
+    //   experimentSetup.getGroupMembersTextBox().type(testGroupMembers)
+    //   experimentSetup.getSubheader(testLabel2)
+    //   experimentSetup.getBackButton().click()
+    //   experimentSetup.expandAllExperimentLabels()
+    //   experimentSetup.getExperimentLabel(testLabel2).should('be.visible')
+    // })
+
+    // it("deletes Stream Study experiment", () => {
+    //   experimentSetup.deleteExperiment()
+    // })
   })
 })

--- a/cypress/integration/branch/experiment.setup.spec.js
+++ b/cypress/integration/branch/experiment.setup.spec.js
@@ -106,9 +106,8 @@ context("Testing Experiment Selection View", () => {
 
   describe("Tests Data Trial", () => {
 
-    it.only("create and setup a data trial", () => {
+    it.only("collect time series data from (mock) sensor", () => {
       experimentSetup.openNewExperiment('Data Trial')
-      //cy.wait(500)
       
       sensorData.getExperimentOptionsMenu() // gets the click in the helper function
       sensorData.selectMenuOption('Connect')
@@ -116,8 +115,23 @@ context("Testing Experiment Selection View", () => {
       // Select and verify the "Mocked Sensor: Temperature" option
       sensorData.selectSensor('Temperature')
       cy.get('div.sensor-module-connectionLabel-vortex select')
-          .should('have.value', '1');
-
+          .should('have.value', '1')
+      // Assert the connection status
+      sensorData.getSensorConnectionStatus()
+      .should('contain.text', 'Connected: Mocked Sensor')
+      
+      // select the sample rate
+      sensorData.selectSample('100/sec')
+      // TODO: add checks that time series data displays
+      // and UI is disabled during time series checks
+      // Blocker: PT #187949831
+      // also fix expected to find element 5 error (probably just need x-1)
+      for (let i = 0; i <= 5; i++) {
+        sensorData.getDataTrialRow(i).within(() => {
+            sensorData.getRecordButton().click()
+            cy.wait(20000) // wait for new sensor values
+        })
+      }
     })
     // this is pasted code from above
     // it("edit experiment and verify changes", () => {

--- a/cypress/integration/branch/experiment.setup.spec.js
+++ b/cypress/integration/branch/experiment.setup.spec.js
@@ -119,19 +119,54 @@ context("Testing Experiment Selection View", () => {
       // Assert the connection status
       sensorData.getSensorConnectionStatus()
       .should('contain.text', 'Connected: Mocked Sensor')
-      
+
+      // Check that the input fields are disabled
+      const labelSelectors = [
+        'input[placeholder="Label #1"]',
+        'input[placeholder="Label #2"]',
+        'input[placeholder="Label #3"]',
+        'input[placeholder="Label #4"]',
+        'input[placeholder="Label #5"]'
+      ]
+
       // select the sample rate
       sensorData.selectSample('100/sec')
+      sensorData.getRecordButton().first().click()
+      // Check the data collection every 1 second for a total of 5 seconds
+      // Note: after 5 sec Cypress starts failing the test because of missed
+      // time. This should be enough for now to ensure that the test is at 
+      // least starting.
+      const checkTimes = [1, 2, 3, 4, 5]
+      checkTimes.forEach((time) => {
+        cy.wait(time * 100)
+        cy.get('.data-table-field-module-sparkgraphContainer-vortex')
+        .contains(`${time} sec`)
+        .should('be.visible')
+      })
+      labelSelectors.forEach((selector) => {
+        cy.get(selector).should('be.disabled')
+        // Check that the connected icon button is disabled
+        cy.get('div.sensor-module-connectionLabel-vortex select').should('be.disabled')
+
+        // Check that the sample rate dropdown is disabled
+        cy.get('.sensor-module-tsvInfoRow-vortex select').should('be.disabled')
+      })
+      // Checks to make sure that the run automatically stops and final display
+      // is 10 sec
+      cy.wait(2000)
+      cy.get('.data-table-field-module-sparkgraphContainer-vortex')
+        .contains(`10 sec`)
+      
       // TODO: add checks that time series data displays
       // and UI is disabled during time series checks
       // Blocker: PT #187949831
       // also fix expected to find element 5 error (probably just need x-1)
-      for (let i = 0; i <= 5; i++) {
-        sensorData.getDataTrialRow(i).within(() => {
-            sensorData.getRecordButton().click()
-            cy.wait(20000) // wait for new sensor values
-        })
-      }
+    //   for (let i = 0; i <= 5; i++) {
+    //     sensorData.getDataTrialRow(i).within(() => {
+    //         sensorData.getRecordButton().click()
+    //         cy.wait(20000) // wait for new sensor values
+    //     })
+    //   }
     })
     // this is pasted code from above
     // it("edit experiment and verify changes", () => {

--- a/cypress/integration/branch/sensor.data.spec.js
+++ b/cypress/integration/branch/sensor.data.spec.js
@@ -89,8 +89,12 @@ context("Testing Experiment Selection View", () => {
             sensorData.getSensorConnectionStatus()
             .should('contain.text', 'Connected: Mocked Sensor')
         })
-        it.skip("verifies enabled sensor connection UI", () => {
-            sensorData.assertRecordButtonStatus('enabled')
+        it("verifies enabled sensor connection UI", () => {
+            sensorData.getBackButton().click()
+            experimentSetup.getExperiment('Schoolyard Investigation', 1).click()
+            sensorData.getTab('Collect').click()
+            sensorData.getExperimentOptionsMenu() // gets the click in the helper function
+            sensorData.selectMenuOption('Connect')
             sensorData.getSensorConnectionStatus().contains(sensorLabels.mockSensorLabel)
             sensorData.getConnectedSensorValue('Temperature').should('not.contain', '--')
             // Not able to get a second sensor value, Temp is enough for now
@@ -98,16 +102,24 @@ context("Testing Experiment Selection View", () => {
             // sensorData.ConnectedSensorValue('Relative Humidity').should('not.contain','--')
             // sensorData.getConnectedSensorValue('Light').should('not.contain','--')
         })
-        it.skip("disconnects from mock sensor and verify UI", () => {
-            sensorData.getExperimentOptionsMenu().click()
+        it("disconnects from mock sensor and verify UI", () => {
+            sensorData.getBackButton().click()
+            experimentSetup.getExperiment('Schoolyard Investigation', 1).click()
+            sensorData.getTab('Collect').click()
+            sensorData.getExperimentOptionsMenu() // gets the click in the helper function
+            sensorData.selectMenuOption('Connect')
+            sensorData.getExperimentOptionsMenu()
             sensorData.selectMenuOption('Disconnect')
 
             sensorData.getSensorConnectionStatus().contains('No Sensor Connected')
             sensorData.getDisconnectSensorStateIcon().should('exist')
             sensorData.getDisconnectedSensorValue('Temperature').should('contain', '--')
         })
-        it.skip("collects data from (mock) sensor", () => {
-            sensorData.getExperimentOptionsMenu().click()
+        it("collects data from (mock) sensor", () => {
+            sensorData.getBackButton().click()
+            experimentSetup.getExperiment('Schoolyard Investigation', 1).click()
+            sensorData.getTab('Collect').click()
+            sensorData.getExperimentOptionsMenu() // gets the click in the helper function
             sensorData.selectMenuOption('Connect')
 
             for (let i = 0; i <= 5; i++) {

--- a/cypress/integration/branch/sensor.data.spec.js
+++ b/cypress/integration/branch/sensor.data.spec.js
@@ -1,7 +1,7 @@
 import ExperimentSetup from "../../supports/elements/ExperimentSetup"
 import SensorData from "../../supports/elements/SensorData";
 
-context.skip("Testing Experiment Selection View", () => {
+context("Testing Experiment Selection View", () => {
 
     //const branch = "master"
 
@@ -71,10 +71,13 @@ context.skip("Testing Experiment Selection View", () => {
 
     describe("Sensor Connection", () => {
 
-        it("connects to (mock) sensor", () => {
-            sensorData.getExperimentOptionsMenu().should('be.visible').click()
-            sensorData.selectMenuOption('Connect')
-            cy.wait(2000)
+        it.only("connects to (mock) sensor", () => {
+            
+            sensorData.getTab('Collect').should('be.visible').click()
+            sensorData.getSensorConnectionStatus().contains('No Sensor Connected').click()
+            // Assert the connection status
+            sensorData.getSensorConnectionStatus()
+            .should('contain.text', 'Connected: Mocked Sensor')
         })
         it("returning to experiments list should disconnect from sensor", () => {
             sensorData.getBackButton().click()

--- a/cypress/integration/branch/sensor.data.spec.js
+++ b/cypress/integration/branch/sensor.data.spec.js
@@ -70,9 +70,7 @@ context("Testing Experiment Selection View", () => {
     })
 
     describe("Sensor Connection", () => {
-
-        it.only("connects to (mock) sensor", () => {
-            
+        it("connects to (mock) sensor", () => {
             sensorData.getTab('Collect').should('be.visible').click()
             sensorData.getSensorConnectionStatus().contains('No Sensor Connected').click()
             // Assert the connection status
@@ -83,12 +81,15 @@ context("Testing Experiment Selection View", () => {
             sensorData.getBackButton().click()
             experimentSetup.getExperiment('Schoolyard Investigation', 1).click()
             sensorData.getTab('Collect').click()
+            // Assert the disconnect status
             sensorData.getSensorConnectionStatus().should('contain', 'No Sensor Connected')
-            sensorData.getExperimentOptionsMenu().click()
+            sensorData.getExperimentOptionsMenu() // gets the click in the helper function
             sensorData.selectMenuOption('Connect')
-            cy.wait(2000)
+            // Assert the connection status
+            sensorData.getSensorConnectionStatus()
+            .should('contain.text', 'Connected: Mocked Sensor')
         })
-        it("verifies enabled sensor connection UI", () => {
+        it.skip("verifies enabled sensor connection UI", () => {
             sensorData.assertRecordButtonStatus('enabled')
             sensorData.getSensorConnectionStatus().contains(sensorLabels.mockSensorLabel)
             sensorData.getConnectedSensorValue('Temperature').should('not.contain', '--')
@@ -97,7 +98,7 @@ context("Testing Experiment Selection View", () => {
             // sensorData.ConnectedSensorValue('Relative Humidity').should('not.contain','--')
             // sensorData.getConnectedSensorValue('Light').should('not.contain','--')
         })
-        it("disconnects from mock sensor and verify UI", () => {
+        it.skip("disconnects from mock sensor and verify UI", () => {
             sensorData.getExperimentOptionsMenu().click()
             sensorData.selectMenuOption('Disconnect')
 
@@ -105,7 +106,7 @@ context("Testing Experiment Selection View", () => {
             sensorData.getDisconnectSensorStateIcon().should('exist')
             sensorData.getDisconnectedSensorValue('Temperature').should('contain', '--')
         })
-        it("collects data from (mock) sensor", () => {
+        it.skip("collects data from (mock) sensor", () => {
             sensorData.getExperimentOptionsMenu().click()
             sensorData.selectMenuOption('Connect')
 

--- a/cypress/supports/elements/SensorData.js
+++ b/cypress/supports/elements/SensorData.js
@@ -46,7 +46,7 @@ class SensorData {
             cy.get('.sensor-value-module-connectedValue-vortex')
         })
     }
-    selectSensor(input){
+    selectSensor(sensorType){
          // Click to focus on the select dropdown (adjust the selector as needed)
         cy.get('div.sensor-module-connectionLabel-vortex select').focus();
 

--- a/cypress/supports/elements/SensorData.js
+++ b/cypress/supports/elements/SensorData.js
@@ -46,6 +46,22 @@ class SensorData {
             cy.get('.sensor-value-module-connectedValue-vortex')
         })
     }
+    selectSensor(input){
+         // Click to focus on the select dropdown (adjust the selector as needed)
+        cy.get('div.sensor-module-connectionLabel-vortex select').focus();
+
+        if (input === 'Force') {
+            // Select the "Mocked Sensor: Force" option
+            cy.get('div.sensor-module-connectionLabel-vortex select').select('Mocked Sensor: Force');
+            return 'Mocked Sensor: Force';
+        } else if (input === 'Temperature') {
+            // Select the "Mocked Sensor: Temperature" option
+            cy.get('div.sensor-module-connectionLabel-vortex select').select('Mocked Sensor: Temperature');
+            return 'Mocked Sensor: Temperature';
+        } else {
+            throw new Error('Invalid input: please specify either "Force" or "Temperature"');
+        }
+    }
 
     getDataRow(index) {
         return cy.get('.data-table-field-module-refreshSensorReading-vortex').eq(index - 1).parent().parent()

--- a/cypress/supports/elements/SensorData.js
+++ b/cypress/supports/elements/SensorData.js
@@ -77,7 +77,6 @@ class SensorData {
     getRecordButton() {
         return cy.get('[data-test="record-sensor"]')
     }
-
     assertRecordButtonStatus(status) {
         if (status == 'enabled') {
             return this.getRecordButton().should('have.class', 'data-table-field-module-active-vortex')

--- a/cypress/supports/elements/SensorData.js
+++ b/cypress/supports/elements/SensorData.js
@@ -46,7 +46,7 @@ class SensorData {
             cy.get('.sensor-value-module-connectedValue-vortex')
         })
     }
-    selectSensor(sensorType){
+    selectSensor(input){
          // Click to focus on the select dropdown (adjust the selector as needed)
         cy.get('div.sensor-module-connectionLabel-vortex select').focus();
 
@@ -62,9 +62,36 @@ class SensorData {
             throw new Error('Invalid input: please specify either "Force" or "Temperature"');
         }
     }
-
+    selectSample(input) {
+        // Click to focus on the select dropdown (adjust the selector as needed)
+        cy.get('div.sensor-module-tsvInfoRow-vortex select').focus();
+    
+        // Define the valid options
+        const options = [
+            '0.1/sec',
+            '0.5/sec',
+            '1/sec',
+            '2/sec',
+            '5/sec',
+            '20/sec',
+            '50/sec',
+            '100/sec'
+        ];
+    
+        // Check if the input is one of the valid options
+        if (options.includes(input)) {
+            // Select the specified option
+            cy.get('div.sensor-module-tsvInfoRow-vortex select').select(input);
+            return input;
+        } else {
+            throw new Error(`Invalid input: please specify one of the following options: ${options.join(', ')}`);
+        }
+    }
     getDataRow(index) {
         return cy.get('.data-table-field-module-refreshSensorReading-vortex').eq(index - 1).parent().parent()
+    }
+    getDataTrialRow(index) {
+        return cy.get('.data-table-field-module-refreshSensorReading-vortex').eq(index).parent().parent()
     }
 
     getCompletedDataRow(index) {

--- a/cypress/supports/elements/SensorData.js
+++ b/cypress/supports/elements/SensorData.js
@@ -63,6 +63,9 @@ class SensorData {
     getExperimentOptionsMenu() {
         return cy.get('.data-table-field-module-dataTable-vortex').within(() => {
             cy.get('.menu-module-menuIcon-vortex')
+          .should('exist')
+          .and('be.visible')
+          .click({ force: true }) // click is here to get the helper function to work
         })
     }
 


### PR DESCRIPTION
[PT-187792765](https://www.pivotaltracker.com/story/show/187792765)

This PR adds Automation for Time Series Data Display:
- Creation of time series data with fake sensor data.
- Ensure elements display correctly.
- ❌ Checks for deletion of time series data.
- Checks for recording time series data.

Regarding the deletion of time series data, I encountered an issue today where the deletion button doesn’t respond to the mouse click in Cypress. I’m not sure why this is happening. I’ll post about it in the QA channel, but I’ve commented out the drafted code for now. Any insights would be appreciated.